### PR TITLE
fix: Add query encoding to use dedicated function

### DIFF
--- a/scheme.go
+++ b/scheme.go
@@ -3,7 +3,15 @@ package things3
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
+
+// encodeQuery encodes url.Values for Things URL scheme.
+// Things expects %20 for spaces, not + (which is standard form encoding).
+// This is safe because original + characters are encoded as %2B by url.Values.Encode().
+func encodeQuery(query url.Values) string {
+	return strings.ReplaceAll(query.Encode(), "+", "%20")
+}
 
 // Scheme provides URL building for Things URL Scheme.
 // It is stateless and can be reused for multiple URL builds.
@@ -58,7 +66,7 @@ func (s *Scheme) JSON() *JSONBuilder {
 func (s *Scheme) Search(query string) string {
 	q := url.Values{}
 	q.Set("query", query)
-	return fmt.Sprintf("things:///%s?%s", CommandSearch, q.Encode())
+	return fmt.Sprintf("things:///%s?%s", CommandSearch, encodeQuery(q))
 }
 
 // Version returns a URL to get Things version information.

--- a/scheme_builder.go
+++ b/scheme_builder.go
@@ -130,7 +130,7 @@ func (b *TodoBuilder) Build() (string, error) {
 		query.Set(k, v)
 	}
 
-	return fmt.Sprintf("things:///%s?%s", CommandAdd, query.Encode()), nil
+	return fmt.Sprintf("things:///%s?%s", CommandAdd, encodeQuery(query)), nil
 }
 
 // ProjectBuilder builds URLs for creating new projects via the add-project command.
@@ -227,5 +227,5 @@ func (b *ProjectBuilder) Build() (string, error) {
 		query.Set(k, v)
 	}
 
-	return fmt.Sprintf("things:///%s?%s", CommandAddProject, query.Encode()), nil
+	return fmt.Sprintf("things:///%s?%s", CommandAddProject, encodeQuery(query)), nil
 }

--- a/scheme_json.go
+++ b/scheme_json.go
@@ -395,7 +395,7 @@ func (b *JSONBuilder) Build() (string, error) {
 		query.Set(keyReveal, "true")
 	}
 
-	return fmt.Sprintf("things:///%s?%s", CommandJSON, query.Encode()), nil
+	return fmt.Sprintf("things:///%s?%s", CommandJSON, encodeQuery(query)), nil
 }
 
 // AuthJSONBuilder builds URLs for batch operations including updates via the json command.
@@ -513,7 +513,7 @@ func (b *AuthJSONBuilder) Build() (string, error) {
 		query.Set(keyReveal, "true")
 	}
 
-	return fmt.Sprintf("things:///%s?%s", CommandJSON, query.Encode()), nil
+	return fmt.Sprintf("things:///%s?%s", CommandJSON, encodeQuery(query)), nil
 }
 
 // NewTodo creates a new JSONTodoBuilder for use with JSONBuilder.AddTodo.

--- a/scheme_show.go
+++ b/scheme_show.go
@@ -46,5 +46,5 @@ func (b *ShowBuilder) Build() string {
 	if len(query) == 0 {
 		return fmt.Sprintf("things:///%s", CommandShow)
 	}
-	return fmt.Sprintf("things:///%s?%s", CommandShow, query.Encode())
+	return fmt.Sprintf("things:///%s?%s", CommandShow, encodeQuery(query))
 }

--- a/scheme_update.go
+++ b/scheme_update.go
@@ -165,7 +165,7 @@ func (b *UpdateTodoBuilder) Build() (string, error) {
 		query.Set(k, v)
 	}
 
-	return fmt.Sprintf("things:///%s?%s", CommandUpdate, query.Encode()), nil
+	return fmt.Sprintf("things:///%s?%s", CommandUpdate, encodeQuery(query)), nil
 }
 
 // UpdateProjectBuilder builds URLs for updating existing projects via the update-project command.
@@ -288,5 +288,5 @@ func (b *UpdateProjectBuilder) Build() (string, error) {
 		query.Set(k, v)
 	}
 
-	return fmt.Sprintf("things:///%s?%s", CommandUpdateProject, query.Encode()), nil
+	return fmt.Sprintf("things:///%s?%s", CommandUpdateProject, encodeQuery(query)), nil
 }


### PR DESCRIPTION
Close #12 

- Refactor query encoding across multiple builder files to use the new `encodeQuery` function for improved consistency and clarity.
- Ensure that URL encoding correctly represents spaces as `%20` and handles `+` characters appropriately.
- Enhance test coverage for encoding functionalities to verify expected behavior with various input scenarios.