### PR TITLE
chore: create GitHub Actions workflow for tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Format Check
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version-file: 'go.mod'
           cache: true
 
       # Build first to catch compile errors early

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
 
       - name: Get version from tag
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Update CLI go.mod version
+        run: |
+          cd cmd/things3
+          go get github.com/moond4rk/things3@${{ steps.version.outputs.VERSION }}
+          go mod tidy
+
+      - name: Build CLI
+        run: |
+          cd cmd/things3
+          go build -ldflags "-X github.com/moond4rk/things3/cmd/things3/cmd.version=${{ steps.version.outputs.VERSION }}" -o things3
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: cmd/things3/things3
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 
@@ -29,7 +29,11 @@ jobs:
       - name: Update CLI go.mod version
         run: |
           cd cmd/things3
-          go get github.com/moond4rk/things3@${{ steps.version.outputs.VERSION }}
+          go mod edit -replace github.com/moond4rk/things3=../..
+          go mod tidy
+          # Remove replace directive for release build
+          go mod edit -dropreplace github.com/moond4rk/things3
+          go mod edit -require github.com/moond4rk/things3@${{ steps.version.outputs.VERSION }}
           go mod tidy
 
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -30,13 +32,10 @@ jobs:
           go get github.com/moond4rk/things3@${{ steps.version.outputs.VERSION }}
           go mod tidy
 
-      - name: Build CLI
-        run: |
-          cd cmd/things3
-          go build -ldflags "-X github.com/moond4rk/things3/cmd/things3/cmd.version=${{ steps.version.outputs.VERSION }}" -o things3
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          files: cmd/things3/things3
-          generate_release_notes: true
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          distribution: goreleaser
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,7 @@ results/
 !.typos.toml
 !.github/*.yml
 !.codecov.yml
+!.goreleaser.yml
 
 # Things3 binary
 /things3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,9 +5,10 @@ builds:
   - id: things3
     dir: cmd/things3
     binary: things3
+    env:
+      - CGO_ENABLED=1
     goos:
       - darwin
-      - linux
     goarch:
       - amd64
       - arm64
@@ -19,10 +20,7 @@ builds:
 
 archives:
   - format: tar.gz
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- if eq .Os "darwin" }}macOS{{else}}{{ .Os }}{{ end }}_
-      {{- if eq .Arch "amd64" }}Intel{{ else if eq .Arch "arm64" }}Apple_Silicon{{ else }}{{ .Arch }}{{ end }}
+    name_template: "{{ .ProjectName }}_macos_{{ if eq .Arch \"arm64\" }}m1{{ else }}intel{{ end }}"
 
 checksum:
   disable: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+project_name: things3
+
+builds:
+  - id: things3
+    dir: cmd/things3
+    binary: things3
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/moond4rk/things3/cmd/things3/cmd.version={{.Version}}
+      - -X github.com/moond4rk/things3/cmd/things3/cmd.commit={{.Commit}}
+      - -X github.com/moond4rk/things3/cmd/things3/cmd.buildDate={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- if eq .Os "darwin" }}macOS{{else}}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}Intel{{ else if eq .Arch "arm64" }}Apple_Silicon{{ else }}{{ .Arch }}{{ end }}
+
+checksum:
+  disable: true
+
+changelog:
+  use: github
+  sort: asc
+
+release:
+  github:
+    owner: moonD4rk
+    name: things3
+  draft: false
+  prerelease: auto


### PR DESCRIPTION
Close #30 

- Automate the release process to streamline the creation of GitHub releases
- Ensure the CLI is built with the correct version extracted from the tag
- Include release notes and attach the built CLI in the GitHub release