### PR TITLE
fix: use local replace for go mod tidy in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,12 @@ jobs:
       - name: Update CLI dependency
         run: |
           cd cmd/things3
-          go mod edit -require github.com/moond4rk/things3@${{ inputs.version }}
+          # Use local code for tidy since the tag doesn't exist yet
+          go mod edit -replace github.com/moond4rk/things3=../..
           go mod tidy
+          # Replace with formal version for release
+          go mod edit -dropreplace github.com/moond4rk/things3
+          go mod edit -require github.com/moond4rk/things3@${{ inputs.version }}
 
       - name: Commit and tag
         run: |


### PR DESCRIPTION
go mod tidy runs before the tag is created, so the version doesn't exist on the module proxy yet. Use replace directive with local code for tidy, then set the formal version for release.