### PR TITLE
revert: remove release test commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,8 @@ jobs:
       - name: Update CLI dependency
         run: |
           cd cmd/things3
-          # Use local code for tidy since the tag doesn't exist yet
-          go mod edit -replace github.com/moond4rk/things3=../..
-          go mod tidy
-          # Replace with formal version for release
-          go mod edit -dropreplace github.com/moond4rk/things3
           go mod edit -require github.com/moond4rk/things3@${{ inputs.version }}
+          go mod tidy
 
       - name: Commit and tag
         run: |

--- a/cmd/things3/go.mod
+++ b/cmd/things3/go.mod
@@ -4,7 +4,7 @@ go 1.25.4
 
 require (
 	github.com/goccy/go-yaml v1.19.2
-	github.com/moond4rk/things3 v0.5.0
+	github.com/moond4rk/things3 v0.4.0
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/cmd/things3/go.sum
+++ b/cmd/things3/go.sum
@@ -7,6 +7,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-sqlite3 v1.14.33 h1:A5blZ5ulQo2AtayQ9/limgHEkFreKj1Dv226a1K73s0=
 github.com/mattn/go-sqlite3 v1.14.33/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/moond4rk/things3 v0.4.0 h1:+2PCdxmwtrGfP/MdxlqTklTU8P1MZQ8UWxKQESdaqmw=
+github.com/moond4rk/things3 v0.4.0/go.mod h1:Rhz12Q0hg5Z67L/MC873bz0YGu37vB8x8OMyZ1j7Udo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Revert the following commits created by release workflow testing:
- 39cbc5b chore: release v0.5.0
- 10936c3 chore: release v0.5.0-rc.2
- 5451926 fix: use local replace for go mod tidy in release workflow (#35)
- 6deb20f chore: release v0.5.0-rc.1

Reset cmd/things3/go.mod back to v0.4.0 and restore release.yml to the state from #34.