### PR TITLE
fix: address code quality issues (P0-P2)

### DIFF
--- a/cmd/things3/cmd/output_test.go
+++ b/cmd/things3/cmd/output_test.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moond4rk/things3"
+)
+
+func TestShortUUID(t *testing.T) {
+	tests := []struct {
+		name     string
+		uuid     string
+		expected string
+	}{
+		{"long UUID", "ABCDEFGH12345678", "ABCDEFGH"},
+		{"exactly 8", "ABCDEFGH", "ABCDEFGH"},
+		{"short", "ABC", "ABC"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, shortUUID(tt.uuid))
+		})
+	}
+}
+
+func TestFormatTaskType(t *testing.T) {
+	tests := []struct {
+		taskType things3.TaskType
+		expected string
+	}{
+		{things3.TaskTypeTodo, "todo"},
+		{things3.TaskTypeProject, "project"},
+		{things3.TaskTypeHeading, "heading"},
+		{things3.TaskType(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatTaskType(tt.taskType))
+		})
+	}
+}
+
+func TestFormatTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []string
+		expected string
+	}{
+		{"nil", nil, ""},
+		{"empty", []string{}, ""},
+		{"single", []string{"work"}, "#work"},
+		{"multiple", []string{"work", "urgent"}, "#work #urgent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatTags(tt.tags))
+		})
+	}
+}
+
+func TestGetRelevantDate(t *testing.T) {
+	d := time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		task     things3.Task
+		expected string
+	}{
+		{
+			name:     "no dates",
+			task:     things3.Task{},
+			expected: "",
+		},
+		{
+			name:     "start date only",
+			task:     things3.Task{StartDate: &d},
+			expected: "2025-03-15",
+		},
+		{
+			name:     "deadline only",
+			task:     things3.Task{Deadline: &d},
+			expected: "due:2025-03-15",
+		},
+		{
+			name:     "stop date only",
+			task:     things3.Task{StopDate: &d},
+			expected: "2025-03-15",
+		},
+		{
+			name:     "stop date takes priority over deadline",
+			task:     things3.Task{StopDate: &d, Deadline: &d},
+			expected: "2025-03-15",
+		},
+		{
+			name:     "deadline takes priority over start date",
+			task:     things3.Task{Deadline: &d, StartDate: &d},
+			expected: "due:2025-03-15",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getRelevantDate(&tt.task))
+		})
+	}
+}
+
+func TestApplyLimit(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5}
+
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, applyLimit(items, 0))
+	assert.Equal(t, []int{1, 2, 3}, applyLimit(items, 3))
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, applyLimit(items, 10))
+	assert.Equal(t, []int{1}, applyLimit(items, 1))
+}
+
+func TestFormatTaskLine(t *testing.T) {
+	task := things3.Task{
+		UUID:   "ABCDEFGH12345678",
+		Type:   things3.TaskTypeTodo,
+		Status: things3.StatusIncomplete,
+		Title:  "Buy milk",
+	}
+	line := formatTaskLine(&task)
+	assert.Contains(t, line, "[ ]")
+	assert.Contains(t, line, "ABCDEFGH")
+	assert.Contains(t, line, "todo")
+	assert.Contains(t, line, "Buy milk")
+
+	// Completed task
+	task.Status = things3.StatusCompleted
+	line = formatTaskLine(&task)
+	assert.Contains(t, line, "[x]")
+
+	// Canceled task
+	task.Status = things3.StatusCanceled
+	line = formatTaskLine(&task)
+	assert.Contains(t, line, "[-]")
+
+	// With tags
+	task.Tags = []string{"shopping"}
+	line = formatTaskLine(&task)
+	assert.Contains(t, line, "#shopping")
+}
+
+func TestWriteTasks_Text(t *testing.T) {
+	var buf bytes.Buffer
+	tasks := []things3.Task{
+		{UUID: "uuid1234abcd", Type: things3.TaskTypeTodo, Title: "Task 1"},
+	}
+	err := writeTasks(&buf, tasks, formatText)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "STATUS")
+	assert.Contains(t, output, "Task 1")
+}
+
+func TestWriteTasks_EmptyText(t *testing.T) {
+	var buf bytes.Buffer
+	err := writeTasks(&buf, nil, formatText)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestWriteTasks_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	tasks := []things3.Task{
+		{UUID: "uuid1234", Type: things3.TaskTypeTodo, Title: "Task 1"},
+	}
+	err := writeTasks(&buf, tasks, formatJSON)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"title": "Task 1"`)
+}
+
+func TestWriteAreas_Text(t *testing.T) {
+	var buf bytes.Buffer
+	areas := []things3.Area{
+		{UUID: "a1", Title: "Work"},
+		{UUID: "a2", Title: "Personal"},
+	}
+	err := writeAreas(&buf, areas, formatText)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "- Work\n")
+	assert.Contains(t, buf.String(), "- Personal\n")
+}
+
+func TestWriteTags_Text(t *testing.T) {
+	var buf bytes.Buffer
+	tags := []things3.Tag{
+		{UUID: "t1", Title: "urgent"},
+	}
+	err := writeTags(&buf, tags, formatText)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "- urgent\n")
+}

--- a/doc.go
+++ b/doc.go
@@ -7,26 +7,26 @@
 //   - Read-only access to the Things 3 SQLite database for querying tasks, projects, areas, and tags
 //   - Full Things URL Scheme support for creating, updating, and navigating to items
 //
-// # Database Access
+// # Getting Started
 //
-// Create a database connection and query tasks:
+// All operations go through a single Client:
 //
-//	db, err := things3.NewDB()
+//	client, err := things3.NewClient()
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	defer db.Close()
+//	defer client.Close()
 //
 //	// Convenience methods
-//	inbox, _ := db.Inbox(ctx)
-//	today, _ := db.Today(ctx)
-//	todos, _ := db.Todos(ctx)
+//	inbox, _ := client.Inbox(ctx)
+//	today, _ := client.Today(ctx)
+//	todos, _ := client.Todos(ctx)
 //
 // # Fluent Query Builder
 //
 // For complex queries, use the type-safe fluent query builder:
 //
-//	tasks, _ := db.Tasks().
+//	tasks, _ := client.Tasks().
 //	    Type().Todo().
 //	    Status().Incomplete().
 //	    StartDate().Future().
@@ -34,28 +34,24 @@
 //
 // # URL Scheme
 //
-// Create Things URLs for automation and integration:
+// Create and update items via Things URL Scheme:
 //
-//	scheme := things3.NewScheme()
-//
-//	// Create a new todo
-//	url, _ := scheme.Todo().
+//	// Create a new to-do
+//	client.AddTodo().
 //	    Title("Buy groceries").
-//	    When(things3.WhenToday).
+//	    When(things3.Today()).
 //	    Tags("shopping").
-//	    Build()
+//	    Execute(ctx)
 //
-//	// Update existing items (requires auth token)
-//	token, _ := db.Token(ctx)
-//	auth := scheme.WithToken(token)
-//	url, _ := auth.UpdateTodo("uuid").Completed(true).Build()
+//	// Update existing items (auth token managed automatically)
+//	client.UpdateTodo("uuid").Completed(true).Execute(ctx)
 //
 // # Configuration
 //
-// Configure the database with functional options:
+// Configure the client with functional options:
 //
-//	db, _ := things3.NewDB(things3.WithDatabasePath("/path/to/main.sqlite"))
-//	db, _ := things3.NewDB(things3.WithPrintSQL(true))
+//	client, _ := things3.NewClient(things3.WithDatabasePath("/path/to/main.sqlite"))
+//	client, _ := things3.NewClient(things3.WithPrintSQL(true))
 //
 // # Database Discovery
 //

--- a/interfaces.go
+++ b/interfaces.go
@@ -133,7 +133,8 @@ type AreaQueryBuilder interface {
 	WithUUID(uuid string) AreaQueryBuilder
 	WithTitle(title string) AreaQueryBuilder
 	Visible(visible bool) AreaQueryBuilder
-	InTag(tag any) AreaQueryBuilder
+	InTag(title string) AreaQueryBuilder
+	HasTag(has bool) AreaQueryBuilder
 	IncludeItems(include bool) AreaQueryBuilder
 }
 
@@ -264,7 +265,7 @@ type ShowNavigator interface {
 	Query(query string) ShowNavigator
 	Filter(tags ...string) ShowNavigator
 
-	Build() string
+	Build() (string, error)
 	Execute(ctx context.Context) error
 }
 

--- a/models.go
+++ b/models.go
@@ -2,6 +2,13 @@ package things3
 
 import "time"
 
+// Task type string constants.
+const (
+	taskTypeStringTodo    = "to-do"
+	taskTypeStringProject = "project"
+	taskTypeStringHeading = "heading"
+)
+
 // Status string constants for ChecklistItem.
 const (
 	statusStringIncomplete = "incomplete"

--- a/query_area.go
+++ b/query_area.go
@@ -11,7 +11,8 @@ type areaQuery struct {
 	uuid         *string
 	title        *string
 	visible      *bool
-	tagTitle     any // string, bool, or nil
+	tagTitle     *string // specific tag title
+	hasTag       *bool   // true: has tags, false: no tags
 	includeItems bool
 }
 
@@ -42,9 +43,15 @@ func (q *areaQuery) Visible(visible bool) AreaQueryBuilder {
 	return q
 }
 
-// InTag filters areas by tag.
-func (q *areaQuery) InTag(tag any) AreaQueryBuilder {
-	q.tagTitle = tag
+// InTag filters areas by a specific tag title.
+func (q *areaQuery) InTag(title string) AreaQueryBuilder {
+	q.tagTitle = &title
+	return q
+}
+
+// HasTag filters areas by whether they have any tags.
+func (q *areaQuery) HasTag(has bool) AreaQueryBuilder {
+	q.hasTag = &has
 	return q
 }
 
@@ -67,7 +74,13 @@ func (q *areaQuery) buildWhere() string {
 	if q.visible != nil {
 		fb.addTruthy("AREA.visible", q.visible)
 	}
-	fb.addEqual("TAG.title", q.tagTitle)
+
+	// Tag filter: specific title or has/no tags
+	if q.tagTitle != nil {
+		fb.addEqual("TAG.title", *q.tagTitle)
+	} else if q.hasTag != nil {
+		fb.addEqual("TAG.title", *q.hasTag)
+	}
 
 	return fb.sql()
 }

--- a/scheme.go
+++ b/scheme.go
@@ -129,7 +129,10 @@ func (s *scheme) executeNavigation(ctx context.Context, uri string) error {
 
 // Show opens Things and shows the item with the given UUID.
 func (s *scheme) Show(ctx context.Context, uuid string) error {
-	uri := s.ShowBuilder().ID(uuid).Build()
+	uri, err := s.ShowBuilder().ID(uuid).Build()
+	if err != nil {
+		return err
+	}
 	return s.executeNavigation(ctx, uri)
 }
 

--- a/scheme_show.go
+++ b/scheme_show.go
@@ -39,22 +39,25 @@ func (b *showBuilder) Filter(tags ...string) ShowNavigator {
 }
 
 // Build returns the Things URL for the show command.
-func (b *showBuilder) Build() string {
+func (b *showBuilder) Build() (string, error) {
 	query := url.Values{}
 	for k, v := range b.params {
 		query.Set(k, v)
 	}
 
 	if len(query) == 0 {
-		return fmt.Sprintf("things:///%s", CommandShow)
+		return fmt.Sprintf("things:///%s", CommandShow), nil
 	}
-	return fmt.Sprintf("things:///%s?%s", CommandShow, encodeQuery(query))
+	return fmt.Sprintf("things:///%s?%s", CommandShow, encodeQuery(query)), nil
 }
 
 // Execute builds and executes the show URL.
 // By default, brings Things to foreground since the user wants to view content.
 // Use WithBackground() option to run in background without stealing focus.
 func (b *showBuilder) Execute(ctx context.Context) error {
-	uri := b.Build()
+	uri, err := b.Build()
+	if err != nil {
+		return err
+	}
 	return b.scheme.executeNavigation(ctx, uri)
 }

--- a/scheme_test.go
+++ b/scheme_test.go
@@ -543,7 +543,8 @@ func TestAddProjectBuilder_FullProject(t *testing.T) {
 
 func TestShowBuilder_ID(t *testing.T) {
 	scheme := newScheme()
-	thingsURL := scheme.ShowBuilder().ID("uuid-123").Build()
+	thingsURL, err := scheme.ShowBuilder().ID("uuid-123").Build()
+	require.NoError(t, err)
 
 	cmd, params := parseThingsURL(t, thingsURL)
 	assert.Equal(t, "show", cmd)
@@ -571,7 +572,8 @@ func TestShowBuilder_List(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.list), func(t *testing.T) {
 			scheme := newScheme()
-			thingsURL := scheme.ShowBuilder().List(tt.list).Build()
+			thingsURL, err := scheme.ShowBuilder().List(tt.list).Build()
+			require.NoError(t, err)
 
 			cmd, params := parseThingsURL(t, thingsURL)
 			require.Equal(t, "show", cmd)
@@ -582,7 +584,8 @@ func TestShowBuilder_List(t *testing.T) {
 
 func TestShowBuilder_Query(t *testing.T) {
 	scheme := newScheme()
-	thingsURL := scheme.ShowBuilder().Query("My Project").Build()
+	thingsURL, err := scheme.ShowBuilder().Query("My Project").Build()
+	require.NoError(t, err)
 
 	cmd, params := parseThingsURL(t, thingsURL)
 	assert.Equal(t, "show", cmd)
@@ -591,7 +594,8 @@ func TestShowBuilder_Query(t *testing.T) {
 
 func TestShowBuilder_Filter(t *testing.T) {
 	scheme := newScheme()
-	thingsURL := scheme.ShowBuilder().List(ListToday).Filter("work", "urgent").Build()
+	thingsURL, err := scheme.ShowBuilder().List(ListToday).Filter("work", "urgent").Build()
+	require.NoError(t, err)
 
 	cmd, params := parseThingsURL(t, thingsURL)
 	assert.Equal(t, "show", cmd)
@@ -601,7 +605,8 @@ func TestShowBuilder_Filter(t *testing.T) {
 
 func TestShowBuilder_NoParams(t *testing.T) {
 	scheme := newScheme()
-	thingsURL := scheme.ShowBuilder().Build()
+	thingsURL, err := scheme.ShowBuilder().Build()
+	require.NoError(t, err)
 	assert.Equal(t, "things:///show", thingsURL)
 }
 
@@ -2006,7 +2011,7 @@ func TestURLEncoding_SpacesAsPercent20(t *testing.T) {
 		{
 			name: "ShowBuilder with space in query",
 			buildURL: func() (string, error) {
-				return newScheme().ShowBuilder().Query("My Project").Build(), nil
+				return newScheme().ShowBuilder().Query("My Project").Build()
 			},
 		},
 		{

--- a/sql.go
+++ b/sql.go
@@ -198,7 +198,7 @@ func buildChecklistItemsSQL() string {
 			CHECKLIST_ITEM.task = ?
 		ORDER BY CHECKLIST_ITEM."index"
 	`, filterIsIncomplete, filterIsCanceled, filterIsCompleted,
-		colModificationDate, colModificationDate, tableChecklistItem)
+		colCreationDate, colModificationDate, tableChecklistItem)
 }
 
 // buildTagsOfTaskSQL builds the SQL query for fetching tags of a task.

--- a/types.go
+++ b/types.go
@@ -1,6 +1,9 @@
 package things3
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // String constant for unknown enum values.
 const unknownString = "unknown"
@@ -22,11 +25,11 @@ const (
 func (t TaskType) String() string {
 	switch t {
 	case TaskTypeTodo:
-		return "to-do"
+		return taskTypeStringTodo
 	case TaskTypeProject:
-		return "project"
+		return taskTypeStringProject
 	case TaskTypeHeading:
-		return "heading"
+		return taskTypeStringHeading
 	default:
 		return unknownString
 	}
@@ -40,6 +43,48 @@ func (t TaskType) MarshalJSON() ([]byte, error) {
 // MarshalYAML implements yaml.Marshaler for TaskType.
 func (t TaskType) MarshalYAML() (any, error) {
 	return t.String(), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for TaskType.
+func (t *TaskType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	v, err := parseTaskType(s)
+	if err != nil {
+		return err
+	}
+	*t = v
+	return nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for TaskType.
+func (t *TaskType) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	v, err := parseTaskType(s)
+	if err != nil {
+		return err
+	}
+	*t = v
+	return nil
+}
+
+// parseTaskType converts a string to TaskType.
+func parseTaskType(s string) (TaskType, error) {
+	switch s {
+	case taskTypeStringTodo:
+		return TaskTypeTodo, nil
+	case taskTypeStringProject:
+		return TaskTypeProject, nil
+	case taskTypeStringHeading:
+		return TaskTypeHeading, nil
+	default:
+		return 0, fmt.Errorf("things3: unknown task type %q", s)
+	}
 }
 
 // Status represents the completion status of a task.
@@ -58,11 +103,11 @@ const (
 func (s Status) String() string {
 	switch s {
 	case StatusIncomplete:
-		return "incomplete"
+		return statusStringIncomplete
 	case StatusCanceled:
-		return "canceled"
+		return statusStringCanceled
 	case StatusCompleted:
-		return "completed"
+		return statusStringCompleted
 	default:
 		return unknownString
 	}
@@ -76,6 +121,48 @@ func (s Status) MarshalJSON() ([]byte, error) {
 // MarshalYAML implements yaml.Marshaler for Status.
 func (s Status) MarshalYAML() (any, error) {
 	return s.String(), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Status.
+func (s *Status) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	v, err := parseStatus(str)
+	if err != nil {
+		return err
+	}
+	*s = v
+	return nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler for Status.
+func (s *Status) UnmarshalYAML(unmarshal func(any) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	v, err := parseStatus(str)
+	if err != nil {
+		return err
+	}
+	*s = v
+	return nil
+}
+
+// parseStatus converts a string to Status.
+func parseStatus(s string) (Status, error) {
+	switch s {
+	case statusStringIncomplete:
+		return StatusIncomplete, nil
+	case statusStringCanceled:
+		return StatusCanceled, nil
+	case statusStringCompleted:
+		return StatusCompleted, nil
+	default:
+		return 0, fmt.Errorf("things3: unknown status %q", s)
+	}
 }
 
 // IsOpen returns true if the status indicates an open (incomplete) task.

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,107 @@
+package things3
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskType_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		taskType TaskType
+		jsonStr  string
+	}{
+		{TaskTypeTodo, `"to-do"`},
+		{TaskTypeProject, `"project"`},
+		{TaskTypeHeading, `"heading"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonStr, func(t *testing.T) {
+			// Marshal
+			data, err := json.Marshal(tt.taskType)
+			require.NoError(t, err)
+			assert.Equal(t, tt.jsonStr, string(data))
+
+			// Unmarshal
+			var got TaskType
+			err = json.Unmarshal(data, &got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.taskType, got)
+		})
+	}
+}
+
+func TestTaskType_UnmarshalJSON_Unknown(t *testing.T) {
+	var got TaskType
+	err := json.Unmarshal([]byte(`"invalid"`), &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown task type")
+}
+
+func TestStatus_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		status  Status
+		jsonStr string
+	}{
+		{StatusIncomplete, `"incomplete"`},
+		{StatusCanceled, `"canceled"`},
+		{StatusCompleted, `"completed"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonStr, func(t *testing.T) {
+			// Marshal
+			data, err := json.Marshal(tt.status)
+			require.NoError(t, err)
+			assert.Equal(t, tt.jsonStr, string(data))
+
+			// Unmarshal
+			var got Status
+			err = json.Unmarshal(data, &got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.status, got)
+		})
+	}
+}
+
+func TestStatus_UnmarshalJSON_Unknown(t *testing.T) {
+	var got Status
+	err := json.Unmarshal([]byte(`"invalid"`), &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown status")
+}
+
+func TestTaskType_StructRoundTrip(t *testing.T) {
+	type wrapper struct {
+		Type TaskType `json:"type"`
+	}
+
+	original := wrapper{Type: TaskTypeProject}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"project"`)
+
+	var decoded wrapper
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, original, decoded)
+}
+
+func TestStatus_StructRoundTrip(t *testing.T) {
+	type wrapper struct {
+		Status Status `json:"status"`
+	}
+
+	original := wrapper{Status: StatusCompleted}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"completed"`)
+
+	var decoded wrapper
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, original, decoded)
+}


### PR DESCRIPTION
## Summary

- **P0 Bug Fix**: `buildChecklistItemsSQL` used `colModificationDate` for both created and modified columns, causing incorrect checklist item creation dates
- **P1 Thread Safety**: Changed `db.queryCount` from `int` to `atomic.Int64` for concurrent access safety
- **P1 Documentation**: Updated `doc.go` examples from obsolete `NewDB()`/`NewScheme()` to current `NewClient()` API
- **P1 Missing API**: Added `Client.AuthBatch()` method with lazy token loading via `ensureToken`
- **P2 Type Safety**: Split `AreaQueryBuilder.InTag(any)` into `InTag(title string)` + `HasTag(has bool)`
- **P2 API Consistency**: Changed `ShowNavigator.Build()` return from `string` to `(string, error)`
- **P2 Enum Deserialization**: Added `UnmarshalJSON`/`UnmarshalYAML` for `TaskType` and `Status`
- **P2 Test Coverage**: Added CLI output tests (`output_test.go`) and enum round-trip tests (`types_test.go`)
- **Linter Cleanup**: Extracted string constants to resolve `goconst` issues

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run` reports 0 issues
- [ ] CLI tests pass: `cd cmd/things3 && go test ./...`