### PR TITLE
fix: add --skip=validate for two-tag release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,17 @@ jobs:
           GOWORK=off go mod edit -require "github.com/moond4rk/things3@${{ inputs.version }}"
           GOWORK=off go mod tidy
 
-      # Step 4: Commit the CLI module update, tag for Go module system, push
+      # Step 4: Commit the CLI module update (if changed), tag for Go module system, push
       - name: Commit and tag CLI module
         run: |
           git add cmd/things3/go.mod cmd/things3/go.sum
-          git commit -m "chore: release ${{ inputs.version }}"
+          if git diff --cached --quiet; then
+            echo "CLI module dependency already up to date, skipping commit"
+          else
+            git commit -m "chore: release ${{ inputs.version }}"
+            git push origin HEAD:main
+          fi
           git tag "cmd/things3/${{ inputs.version }}"
-          git push origin HEAD:main
           git push origin "cmd/things3/${{ inputs.version }}"
 
       # Step 5: Build and publish binaries via GoReleaser
@@ -83,7 +87,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean
+          args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}


### PR DESCRIPTION
## Summary

- Add `--skip=validate` to GoReleaser args to fix tag-commit mismatch in the two-tag release flow
- Make the commit step idempotent so re-triggering the workflow does not fail on "nothing to commit"

## Context

The two-tag release workflow creates the library tag (`v0.5.0`) on commit A, then advances HEAD to commit B (CLI go.mod update). GoReleaser rejects this because `GORELEASER_CURRENT_TAG=v0.5.0` points to commit A, not HEAD. `--skip=validate` is the [documented way](https://goreleaser.com/cmd/goreleaser_release/) to handle this.

## After merging

Delete existing tags and re-trigger the workflow for v0.5.0:

```bash
# Delete remote tags
git push origin :refs/tags/v0.5.0
git push origin :refs/tags/cmd/things3/v0.5.0

# Re-trigger
gh workflow run release.yml -f version=v0.5.0
```