### PR TITLE
fix: add version and build info for things3 cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,28 @@ Detailed design decisions with rationale.
 Key implementation details and considerations.
 ```
 
+## Release Note Template
+
+Release notes use this format with Library and CLI sections:
+
+```
+# things3 vX.Y.Z - Short Title
+
+One-line summary.
+
+## Breaking Changes (if any)
+Brief description of what changed and migration path.
+
+## Library
+- **Feature name** (#PR): One-line description
+- **Bug fix**: Description (#PR)
+
+## CLI
+- **Feature name** (#PR): One-line description
+
+**Full Changelog**: https://github.com/moonD4rk/things3/compare/vPREV...vX.Y.Z
+```
+
 ## CLI Development (cmd/things3)
 
 CLI uses Cobra with factory function pattern (no `init()`).

--- a/cmd/things3/cmd/version.go
+++ b/cmd/things3/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,33 @@ var (
 	commit    = "none"
 	buildDate = "unknown"
 )
+
+func init() {
+	if version != "dev" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		version = info.Main.Version
+	}
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if len(s.Value) > 8 {
+				commit = s.Value[:8]
+			} else if s.Value != "" {
+				commit = s.Value
+			}
+		case "vcs.time":
+			if s.Value != "" {
+				buildDate = s.Value
+			}
+		}
+	}
+}
 
 // NewVersionCmd creates the version command.
 func NewVersionCmd() *cobra.Command {

--- a/rfcs/002_rfc_database_schema.md
+++ b/rfcs/002_rfc_database_schema.md
@@ -1,6 +1,6 @@
 # RFC 002: Database Schema
 
-Status: Accepted
+Status: Implemented
 Author: @moond4rk
 
 ## Summary

--- a/rfcs/003_rfc_database_api.md
+++ b/rfcs/003_rfc_database_api.md
@@ -5,308 +5,211 @@ Author: @moond4rk
 
 ## Summary
 
-This RFC defines the Database API layer of the things3 Go library. The `NewDB()` entry point provides read-only access to the Things 3 SQLite database with a clean, type-safe interface following Go idioms.
+This RFC defines the Database API layer of the things3 Go library. The internal `db` type provides read-only access to the Things 3 SQLite database with a clean, type-safe interface following Go idioms. Users access database operations through the unified `NewClient()` entry point (see RFC 005).
 
 ## Design
 
 ### Entry Point
 
+The `db` type is internal (unexported). Users access it through `NewClient()`:
+
 ```go
-// DB provides read-only access to the Things 3 database.
-type DB struct {
+// db provides read-only access to the Things 3 database (internal).
+type db struct {
     // internal fields
 }
 
-// NewDB creates a new database connection.
-func NewDB(opts ...DBOption) (*DB, error)
+// newDB creates a new database connection (internal).
+func newDB(opts ...dbOption) (*db, error)
 
-// DBOption configures the database connection.
-type DBOption func(*dbConfig)
-
-func WithDBPath(path string) DBOption
-func WithPrintSQL(enabled bool) DBOption
+// dbOption configures the database connection (internal).
+type dbOption func(*dbConfig)
 ```
 
-### Connection Methods
+Users configure database behavior via `ClientOption`:
 
 ```go
-// Close closes the database connection.
-func (db *DB) Close() error
-
-// Filepath returns the path to the database file.
-func (db *DB) Filepath() string
+things3.WithDatabasePath(path string)  // Custom database path
+things3.WithPrintSQL(enabled bool)     // SQL logging for debugging
 ```
 
 ### Convenience Query Methods
 
-Direct access methods for common queries. All methods accept `context.Context` as the first parameter and return value slices (not pointer slices).
+Direct access methods for common queries. All methods accept `context.Context` as the first parameter and return value slices (not pointer slices). These are exposed on `Client`:
 
 ```go
-// Inbox returns all tasks in the Inbox.
-func (db *DB) Inbox(ctx context.Context) ([]Task, error)
-
-// Today returns all tasks scheduled for today.
-func (db *DB) Today(ctx context.Context) ([]Task, error)
-
-// Upcoming returns all tasks with future start dates.
-func (db *DB) Upcoming(ctx context.Context) ([]Task, error)
-
-// Anytime returns all tasks in the Anytime list.
-func (db *DB) Anytime(ctx context.Context) ([]Task, error)
-
-// Someday returns all tasks in the Someday list.
-func (db *DB) Someday(ctx context.Context) ([]Task, error)
-
-// Logbook returns all completed tasks.
-func (db *DB) Logbook(ctx context.Context) ([]Task, error)
-
-// Trash returns all trashed tasks.
-func (db *DB) Trash(ctx context.Context) ([]Task, error)
-
-// Todos returns all incomplete to-do items.
-func (db *DB) Todos(ctx context.Context) ([]Task, error)
-
-// Projects returns all projects.
-func (db *DB) Projects(ctx context.Context) ([]Task, error)
-
-// Completed returns all completed tasks.
-func (db *DB) Completed(ctx context.Context) ([]Task, error)
-
-// Canceled returns all canceled tasks.
-func (db *DB) Canceled(ctx context.Context) ([]Task, error)
-
-// Deadlines returns all tasks with deadlines.
-func (db *DB) Deadlines(ctx context.Context) ([]Task, error)
-
-// CreatedWithin returns tasks created after the specified time.
-func (db *DB) CreatedWithin(ctx context.Context, since time.Time) ([]Task, error)
-
-// Search returns tasks matching the search query.
-func (db *DB) Search(ctx context.Context, query string) ([]Task, error)
-
-// Get returns a task, area, or tag by UUID.
-func (db *DB) Get(ctx context.Context, uuid string) (any, error)
-
-// ChecklistItems returns checklist items for a task.
-func (db *DB) ChecklistItems(ctx context.Context, taskUUID string) ([]ChecklistItem, error)
+client.Inbox(ctx)                      // Tasks in Inbox
+client.Today(ctx)                      // Today's tasks
+client.Upcoming(ctx)                   // Scheduled future tasks
+client.Anytime(ctx)                    // Anytime tasks
+client.Someday(ctx)                    // Someday tasks
+client.Logbook(ctx)                    // Completed/canceled tasks
+client.Trash(ctx)                      // Trashed tasks
+client.Todos(ctx)                      // All incomplete to-dos
+client.Projects(ctx)                   // All incomplete projects
+client.Completed(ctx)                  // All completed tasks
+client.Canceled(ctx)                   // All canceled tasks
+client.Deadlines(ctx)                  // Tasks with deadlines
+client.CreatedWithin(ctx, since)       // Tasks created after time
+client.Search(ctx, query)             // Search tasks
+client.Get(ctx, uuid)                 // Get task, area, or tag by UUID
+client.ChecklistItems(ctx, taskUUID)  // Checklist items for a task
 ```
 
 ### Query Builders
 
-Builder pattern for complex queries with chainable filter methods and terminal execution methods.
+Builder pattern for complex queries with chainable filter methods and terminal execution methods. All query builders return interfaces, not concrete types (see RFC 006).
 
 ```go
-// Query builder entry points
-func (db *DB) Tasks() *TaskQuery
-func (db *DB) Areas() *AreaQuery
-func (db *DB) Tags() *TagQuery
+// Query builder entry points (on Client)
+client.Tasks() -> TaskQueryBuilder
+client.Areas() -> AreaQueryBuilder
+client.Tags()  -> TagQueryBuilder
 ```
 
-#### TaskQuery
+#### TaskQueryBuilder
+
+Composed of: `TaskQueryExecutor` + `TaskRelationFilter` + `TaskStateFilter` + `TaskTimeFilter`
 
 ```go
-type TaskQuery struct {
-    // internal fields
-}
+// Filter methods (chainable, return TaskQueryBuilder interface)
+WithUUID(uuid string) TaskQueryBuilder
+WithUUIDPrefix(prefix string) TaskQueryBuilder
+InTag(title string) TaskQueryBuilder
+InProject(uuid string) TaskQueryBuilder
+InArea(uuid string) TaskQueryBuilder
+InHeading(uuid string) TaskQueryBuilder
+HasArea(has bool) TaskQueryBuilder
+HasProject(has bool) TaskQueryBuilder
+HasHeading(has bool) TaskQueryBuilder
+HasTag(has bool) TaskQueryBuilder
+Trashed(trashed bool) TaskQueryBuilder
+ContextTrashed(trashed bool) TaskQueryBuilder
+WithDeadlineSuppressed(suppressed bool) TaskQueryBuilder
+IncludeItems(include bool) TaskQueryBuilder
+OrderByTodayIndex() TaskQueryBuilder
+CreatedAfter(t time.Time) TaskQueryBuilder
+Search(query string) TaskQueryBuilder
 
-// Filter methods (chainable)
-func (q *TaskQuery) WithUUID(uuid string) *TaskQuery
-func (q *TaskQuery) InTag(title string) *TaskQuery
-func (q *TaskQuery) InProject(projectUUID string) *TaskQuery
-func (q *TaskQuery) InArea(areaUUID string) *TaskQuery
-func (q *TaskQuery) InHeading(headingUUID string) *TaskQuery
-func (q *TaskQuery) Trashed(trashed bool) *TaskQuery
-func (q *TaskQuery) HasArea(has bool) *TaskQuery
-func (q *TaskQuery) HasProject(has bool) *TaskQuery
-func (q *TaskQuery) HasHeading(has bool) *TaskQuery
-func (q *TaskQuery) HasTag(has bool) *TaskQuery
-func (q *TaskQuery) WithDeadlineSuppressed(suppressed bool) *TaskQuery
-func (q *TaskQuery) ContextTrashed(trashed bool) *TaskQuery
-func (q *TaskQuery) IncludeItems(include bool) *TaskQuery
-func (q *TaskQuery) OrderByTodayIndex() *TaskQuery
-func (q *TaskQuery) CreatedAfter(t time.Time) *TaskQuery
-func (q *TaskQuery) Search(query string) *TaskQuery
-
-// Type-safe sub-builders (chainable, return *TaskQuery)
-func (q *TaskQuery) Type() *TypeFilter
-func (q *TaskQuery) Status() *StatusFilter
-func (q *TaskQuery) Start() *StartFilter
-func (q *TaskQuery) StartDate() *DateFilter
-func (q *TaskQuery) StopDate() *DateFilter
-func (q *TaskQuery) Deadline() *DateFilter
+// Type-safe sub-builders (return sub-builder interfaces)
+Type() TypeFilterBuilder      // Todo(), Project(), Heading()
+Status() StatusFilterBuilder  // Incomplete(), Completed(), Canceled(), Any()
+Start() StartFilterBuilder    // Inbox(), Anytime(), Someday()
+StartDate() DateFilterBuilder // Exists(), Future(), Past(), On(), Before(), etc.
+StopDate() DateFilterBuilder
+Deadline() DateFilterBuilder
 
 // Terminal methods (execute query)
-func (q *TaskQuery) All(ctx context.Context) ([]Task, error)
-func (q *TaskQuery) First(ctx context.Context) (*Task, error)
-func (q *TaskQuery) Count(ctx context.Context) (int, error)
+All(ctx context.Context) ([]Task, error)
+First(ctx context.Context) (*Task, error)
+Count(ctx context.Context) (int, error)
 ```
 
-#### Type-Safe Sub-Builders
-
-These sub-builders provide compile-time type safety for filter values:
+#### AreaQueryBuilder
 
 ```go
-// TypeFilter for task type filtering
-type TypeFilter struct { /* internal */ }
-func (f *TypeFilter) Todo() *TaskQuery
-func (f *TypeFilter) Project() *TaskQuery
-func (f *TypeFilter) Heading() *TaskQuery
+// Filter methods (chainable, return AreaQueryBuilder interface)
+WithUUID(uuid string) AreaQueryBuilder
+WithTitle(title string) AreaQueryBuilder
+Visible(visible bool) AreaQueryBuilder
+InTag(title string) AreaQueryBuilder   // Filter by specific tag title
+HasTag(has bool) AreaQueryBuilder      // Filter by whether area has any tags
+IncludeItems(include bool) AreaQueryBuilder
 
-// StatusFilter for task status filtering
-type StatusFilter struct { /* internal */ }
-func (f *StatusFilter) Incomplete() *TaskQuery
-func (f *StatusFilter) Completed() *TaskQuery
-func (f *StatusFilter) Canceled() *TaskQuery
-func (f *StatusFilter) Any() *TaskQuery
-
-// StartFilter for start bucket filtering
-type StartFilter struct { /* internal */ }
-func (f *StartFilter) Inbox() *TaskQuery
-func (f *StartFilter) Anytime() *TaskQuery
-func (f *StartFilter) Someday() *TaskQuery
-
-// DateFilter for date-based filtering
-type DateFilter struct { /* internal */ }
-func (f *DateFilter) Exists(exists bool) *TaskQuery
-func (f *DateFilter) Future() *TaskQuery
-func (f *DateFilter) Past() *TaskQuery
-func (f *DateFilter) On(date time.Time) *TaskQuery
-func (f *DateFilter) Before(date time.Time) *TaskQuery
-func (f *DateFilter) OnOrBefore(date time.Time) *TaskQuery
-func (f *DateFilter) After(date time.Time) *TaskQuery
-func (f *DateFilter) OnOrAfter(date time.Time) *TaskQuery
+// Terminal methods
+All(ctx context.Context) ([]Area, error)
+First(ctx context.Context) (*Area, error)
+Count(ctx context.Context) (int, error)
 ```
 
-#### AreaQuery
+#### TagQueryBuilder
 
 ```go
-type AreaQuery struct {
-    // internal fields
-}
+// Filter methods (chainable, return TagQueryBuilder interface)
+WithUUID(uuid string) TagQueryBuilder
+WithTitle(title string) TagQueryBuilder
+WithParent(parentUUID string) TagQueryBuilder
+IncludeItems(include bool) TagQueryBuilder
 
-// Filter methods (chainable)
-func (q *AreaQuery) WithUUID(uuid string) *AreaQuery
-func (q *AreaQuery) WithTitle(title string) *AreaQuery
-func (q *AreaQuery) Visible(visible bool) *AreaQuery
-func (q *AreaQuery) InTag(tag any) *AreaQuery
-func (q *AreaQuery) IncludeItems(include bool) *AreaQuery
-
-// Terminal methods (execute query)
-func (q *AreaQuery) All(ctx context.Context) ([]Area, error)
-func (q *AreaQuery) First(ctx context.Context) (*Area, error)
-func (q *AreaQuery) Count(ctx context.Context) (int, error)
-```
-
-#### TagQuery
-
-```go
-type TagQuery struct {
-    // internal fields
-}
-
-// Filter methods (chainable)
-func (q *TagQuery) WithUUID(uuid string) *TagQuery
-func (q *TagQuery) WithTitle(title string) *TagQuery
-func (q *TagQuery) WithParent(parentUUID string) *TagQuery
-func (q *TagQuery) IncludeItems(include bool) *TagQuery
-
-// Terminal methods (execute query)
-func (q *TagQuery) All(ctx context.Context) ([]Tag, error)
-func (q *TagQuery) First(ctx context.Context) (*Tag, error)
-func (q *TagQuery) Count(ctx context.Context) (int, error)
+// Terminal methods
+All(ctx context.Context) ([]Tag, error)
+First(ctx context.Context) (*Tag, error)
 ```
 
 ### Token Retrieval
 
-The `Token()` method retrieves the authentication token required for URL Scheme update operations. This bridges the DB layer with the URL Scheme layer.
-
-```go
-// Token returns the authentication token for URL Scheme update operations.
-// The token is stored in the TMSettings table.
-func (db *DB) Token(ctx context.Context) (string, error)
-```
+The internal `db.Token()` method retrieves the authentication token required for URL Scheme update operations. This bridges the database layer with the URL Scheme layer. Token management is handled automatically by the `Client` (see RFC 005).
 
 ## Usage Examples
 
 ### Basic Usage
 
 ```go
-db, err := things3.NewDB()
+client, err := things3.NewClient()
 if err != nil {
     return err
 }
-defer db.Close()
+defer client.Close()
 
 // Convenience methods
-tasks, _ := db.Inbox(ctx)
-tasks, _ := db.Today(ctx)
-tasks, _ := db.Upcoming(ctx)
-tasks, _ := db.Todos(ctx)
-tasks, _ := db.Projects(ctx)
+tasks, _ := client.Inbox(ctx)
+tasks, _ := client.Today(ctx)
+tasks, _ := client.Upcoming(ctx)
+tasks, _ := client.Todos(ctx)
+tasks, _ := client.Projects(ctx)
 ```
 
 ### Query Builder with Type-Safe Sub-Builders
 
 ```go
 // Find all incomplete todos with a specific tag
-tasks, _ := db.Tasks().
+tasks, _ := client.Tasks().
     Type().Todo().
     Status().Incomplete().
     InTag("work").
     All(ctx)
 
 // Find a specific task by UUID
-task, _ := db.Tasks().
+task, _ := client.Tasks().
     WithUUID("task-uuid").
     First(ctx)
 
 // Find all tasks in a project
-tasks, _ := db.Tasks().
+tasks, _ := client.Tasks().
     InProject("project-uuid").
     All(ctx)
 
 // Find tasks with deadlines in the past
-tasks, _ := db.Tasks().
+tasks, _ := client.Tasks().
     Deadline().Past().
     All(ctx)
 
 // Find tasks starting in the future
-tasks, _ := db.Tasks().
+tasks, _ := client.Tasks().
     StartDate().Future().
     All(ctx)
 
-// Find tasks with deadlines before a specific date
-tasks, _ := db.Tasks().
-    Deadline().Before(time.Now().AddDate(0, 0, 7)).
-    All(ctx)
-
 // Count tasks with a deadline
-count, _ := db.Tasks().
+count, _ := client.Tasks().
     Deadline().Exists(true).
     Count(ctx)
 
-// Find tasks created within last 7 days
-tasks, _ := db.Tasks().
-    CreatedAfter(things3.DaysAgo(7)).
-    All(ctx)
-
 // Search for tasks
-tasks, _ := db.Tasks().
+tasks, _ := client.Tasks().
     Search("meeting").
     All(ctx)
 ```
 
 ### With URL Scheme Integration
 
-```go
-// Get token for URL Scheme update operations
-db, _ := things3.NewDB()
-token, _ := db.Token(ctx)
+Token management is automatic via the unified Client:
 
-// Use token with URL Scheme (see RFC 004)
-scheme := things3.NewScheme()
-auth := scheme.WithToken(token)
-url, _ := auth.UpdateTodo("uuid").Completed(true).Build()
+```go
+client, _ := things3.NewClient()
+defer client.Close()
+
+// Update operations auto-fetch token from database
+client.UpdateTodo("uuid").Completed(true).Execute(ctx)
 ```
 
 ## Error Definitions
@@ -329,62 +232,41 @@ var (
 
 ## File Organization
 
-```text
-things3/
-    client.go           # DB type, NewDB(), Close(), Filepath()
-    client_options.go   # DBOption, WithDBPath(), WithPrintSQL()
-    convenience.go      # Inbox(), Today(), Todos(), Projects(), etc.
-    query.go            # TaskQuery builder
-    query_filter.go     # Type-safe sub-builders (StatusFilter, TypeFilter, etc.)
-    query_area.go       # AreaQuery builder
-    query_tag.go        # TagQuery builder
-    filter.go           # Internal SQL filter building
-    sql.go              # SQL query construction
-    models.go           # Task, Area, Tag, ChecklistItem structs
-    types.go            # TaskType, Status, StartBucket enums
-    date.go             # Things date format conversion
-    time_helpers.go     # Time helper functions (DaysAgo, WeeksAgo, etc.)
-    database.go         # Database connection and path discovery
-    url.go              # Things URL scheme support
-    errors.go           # Error definitions
-    constants.go        # Table names, column mappings
-```
-
 | File | Responsibility |
 |------|----------------|
-| `client.go` | DB type definition, NewDB constructor, connection management |
-| `client_options.go` | Functional options pattern for configuration |
-| `convenience.go` | Pre-built queries for common operations |
-| `query.go` | TaskQuery builder with filter and terminal methods |
-| `query_filter.go` | Type-safe sub-builders (StatusFilter, TypeFilter, DateFilter, etc.) |
-| `query_area.go` | AreaQuery builder |
-| `query_tag.go` | TagQuery builder |
-| `filter.go` | Internal filter interface and implementations |
-| `sql.go` | SQL query construction and execution |
+| `client.go` | Client type, NewClient(), unified API entry point |
+| `client_options.go` | ClientOption functional options |
+| `interfaces.go` | All public interface definitions (6 layers) |
+| `db.go` | Internal db type, database operations |
+| `db_options.go` | Internal dbOption functional options |
+| `convenience.go` | Inbox(), Today(), Todos(), Projects(), etc. |
+| `query.go` | taskQuery builder with filter methods |
+| `query_filter.go` | typeFilter, statusFilter, startFilter, dateFilter |
+| `query_area.go` | areaQuery builder |
+| `query_tag.go` | tagQuery builder |
+| `sql.go` | SQL query building and execution |
+| `models.go` | Task, Area, Tag, ChecklistItem structs |
+| `types.go` | TaskType, Status, StartBucket enums |
+| `date.go` | Things date format conversion |
+| `database.go` | Database connection and path discovery |
+| `errors.go` | Error definitions |
+| `constants.go` | Table names, column mappings |
 
 ## Testing Strategy
 
 ### Integration Tests
 
 ```go
-func TestDB_Inbox(t *testing.T) {
-    db, err := things3.NewDB(things3.WithDBPath("testdata/test.sqlite"))
+func TestClient_Inbox(t *testing.T) {
+    client, err := things3.NewClient(
+        things3.WithDatabasePath("testdata/test.sqlite"),
+    )
     require.NoError(t, err)
-    defer db.Close()
+    defer client.Close()
 
-    tasks, err := db.Inbox(context.Background())
+    tasks, err := client.Inbox(context.Background())
     require.NoError(t, err)
     assert.NotEmpty(t, tasks)
-}
-
-func TestDB_Token(t *testing.T) {
-    db, err := things3.NewDB(things3.WithDBPath("testdata/test.sqlite"))
-    require.NoError(t, err)
-    defer db.Close()
-
-    token, err := db.Token(context.Background())
-    require.NoError(t, err)
-    assert.NotEmpty(t, token)
 }
 ```
 
@@ -392,27 +274,24 @@ func TestDB_Token(t *testing.T) {
 
 ```go
 func TestTaskQuery_TypeSafeFilters(t *testing.T) {
-    db, _ := things3.NewDB(things3.WithDBPath("testdata/test.sqlite"))
-    defer db.Close()
+    client, _ := things3.NewClient(
+        things3.WithDatabasePath("testdata/test.sqlite"),
+    )
+    defer client.Close()
 
     tests := []struct {
         name    string
-        query   func() *things3.TaskQuery
+        query   func() things3.TaskQueryBuilder
         wantMin int
     }{
         {
             name:    "all todos",
-            query:   func() *things3.TaskQuery { return db.Tasks().Type().Todo() },
+            query:   func() things3.TaskQueryBuilder { return client.Tasks().Type().Todo() },
             wantMin: 1,
         },
         {
             name:    "incomplete tasks",
-            query:   func() *things3.TaskQuery { return db.Tasks().Status().Incomplete() },
-            wantMin: 0,
-        },
-        {
-            name:    "tasks with deadlines",
-            query:   func() *things3.TaskQuery { return db.Tasks().Deadline().Exists(true) },
+            query:   func() things3.TaskQueryBuilder { return client.Tasks().Status().Incomplete() },
             wantMin: 0,
         },
     }
@@ -433,10 +312,11 @@ func TestTaskQuery_TypeSafeFilters(t *testing.T) {
 |-----------|----------------|
 | Context-First | All query methods accept `context.Context` as first parameter |
 | Builder Pattern | Chainable filter methods with terminal execution methods |
-| Type-Safe Sub-Builders | StatusFilter, TypeFilter, DateFilter provide compile-time safety |
+| Interface-Based | Query builders return interfaces, not concrete types (see RFC 006) |
+| Type-Safe Sub-Builders | StatusFilterBuilder, TypeFilterBuilder, DateFilterBuilder provide compile-time safety |
 | Read-Only | No write operations to the database |
 | Type Safety | Strongly typed query results, no raw SQL exposure |
-| Functional Options | Configuration via `DBOption` functions |
+| Functional Options | Configuration via `ClientOption` functions |
 | Value Semantics | Return value slices (`[]Task`) not pointer slices (`[]*Task`) |
 
 ## References

--- a/rfcs/004_rfc_url_scheme.md
+++ b/rfcs/004_rfc_url_scheme.md
@@ -1,11 +1,11 @@
 # RFC 004: URL Scheme
 
-Status: Draft
+Status: Implemented
 Author: @moond4rk
 
 ## Summary
 
-This RFC defines the URL Scheme API layer of the things3 Go library. The `NewScheme()` entry point provides type-safe URL building and execution for Things 3 URL Scheme commands with compile-time enforcement of authentication requirements.
+This RFC defines the URL Scheme API layer of the things3 Go library. The internal `scheme` type provides type-safe URL building and execution for Things 3 URL Scheme commands. Users access URL scheme operations through the unified `NewClient()` entry point (see RFC 005), which returns public interfaces (see RFC 006) instead of concrete types.
 
 ## Motivation
 
@@ -786,49 +786,6 @@ func TestWithToken_EmptyToken(t *testing.T) {
 
     require.ErrorIs(t, err, things3.ErrEmptyToken)
 }
-```
-
-## Backward Compatibility
-
-### Deprecated Methods (to be removed in v2.0)
-
-The following methods on `Client` are deprecated in favor of `NewScheme()`:
-
-```go
-// Deprecated: Use things3.NewScheme().AddTodo().Build() instead
-func (c *Client) AddTodoURL(params map[string]string) string
-
-// Deprecated: Use things3.NewScheme().WithToken(token).UpdateTodo(id).Build()
-func (c *Client) URL(ctx context.Context, cmd URLCommand, params map[string]string) (string, error)
-```
-
-### Migration Examples
-
-```go
-// Before (deprecated)
-client, _ := things3.New()
-url := client.AddTodoURL(map[string]string{"title": "Task"})
-
-// After (recommended)
-scheme := things3.NewScheme()
-url, _ := scheme.AddTodo().Title("Task").Build()
-```
-
-```go
-// Before (deprecated)
-client, _ := things3.New()
-url, _ := client.URL(ctx, things3.URLCommandUpdate, map[string]string{
-    "id": "uuid",
-    "completed": "true",
-})
-
-// After (recommended) - token required upfront via WithToken
-db, _ := things3.NewDB()
-token, _ := db.Token(ctx)
-
-scheme := things3.NewScheme()
-auth := scheme.WithToken(token)
-url, _ := auth.UpdateTodo("uuid").Completed(true).Build()
 ```
 
 ## Design Principles


### PR DESCRIPTION
- Implement a CLI functionality for querying tasks from the terminal for better user interaction
- Update RFC status for various RFCs to reflect their progress and implementation
- Streamline add and update operations with a builder pattern for cleaner code
- Enhance user access and type safety in the URL Scheme API for a better user experience