### PR TITLE
chore: add homebrew tap formula release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}
+          MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,4 +91,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}
-          MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ archives:
     name_template: "{{ .ProjectName }}_macos_{{ if eq .Arch \"arm64\" }}m1{{ else }}intel{{ end }}"
 
 checksum:
-  disable: true
+  name_template: "checksums.txt"
 
 changelog:
   use: github

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,7 +52,7 @@ brews:
       owner: moonD4rk
       name: homebrew-tap
       branch: main
-      token: "{{ .Env.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN }}"
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_author:
       name: "github-actions[bot]"
       email: "github-actions[bot]@users.noreply.github.com"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,3 +41,26 @@ release:
     name: things3
   draft: false
   prerelease: auto
+
+brews:
+  - name: things3
+    homepage: "https://github.com/moonD4rk/things3"
+    description: "CLI for Things 3 task manager on macOS"
+    license: "Apache-2.0"
+    skip_upload: auto
+    repository:
+      owner: moonD4rk
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: "github-actions[bot]"
+      email: "github-actions[bot]@users.noreply.github.com"
+    commit_msg_template: "brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    install: |
+      bin.install "things3"
+    test: |
+      system "#{bin}/things3", "version"
+    caveats: |
+      things3 requires read access to the Things 3 database.
+      Make sure Things 3 is installed on your Mac.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ A command-line tool for querying your Things 3 tasks from the terminal.
 
 ### Installation
 
-Download pre-built binaries from [GitHub Releases](https://github.com/moonD4rk/things3/releases), or install with Go:
+**Homebrew** (recommended):
+
+```bash
+brew install moond4rk/tap/things3
+```
+
+**Go**:
 
 ```bash
 go install github.com/moond4rk/things3/cmd/things3@latest
@@ -30,7 +36,7 @@ go install github.com/moond4rk/things3/cmd/things3@latest
 
 > **Note**: Requires CGO enabled (uses `go-sqlite3`). macOS only.
 
-If macOS shows "Apple could not verify" when running a downloaded binary, remove the quarantine attribute:
+**Manual**: Download pre-built binaries from [GitHub Releases](https://github.com/moonD4rk/things3/releases). If macOS shows "Apple could not verify", remove the quarantine attribute:
 
 ```bash
 xattr -d com.apple.quarantine /path/to/things3


### PR DESCRIPTION
Close #32 

- Add new environment variable for GitHub token to workflow configuration
- Update GoReleaser version and skip `validate` step in build process
- Specify details for new brew formula and set up commit author information
- Include installation, testing, and usage information in formula