### PR TITLE
feat: add todo/project detail commands and fix list views

### DIFF
--- a/cmd/things3/cmd/list.go
+++ b/cmd/things3/cmd/list.go
@@ -12,10 +12,9 @@ import (
 func NewListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list <view>",
-		Short: "List tasks from various views",
+		Short: "List todos from various views",
 	}
 
-	// Register view subcommands
 	cmd.AddCommand(
 		newInboxCmd(),
 		newTodayCmd(),
@@ -35,7 +34,7 @@ func NewListCmd() *cobra.Command {
 func newInboxCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "inbox",
-		Short: "List tasks in the Inbox",
+		Short: "List todos in the Inbox",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := things3.NewClient()
 			if err != nil {
@@ -43,11 +42,14 @@ func newInboxCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			tasks, err := client.Inbox(cmd.Context())
+			todos, err := client.Todos().
+				Start().Inbox().
+				Status().Incomplete().
+				All(cmd.Context())
 			if err != nil {
 				return err
 			}
-			return outputTasks(cmd, tasks)
+			return outputTodos(cmd, todos)
 		},
 	}
 }
@@ -55,7 +57,7 @@ func newInboxCmd() *cobra.Command {
 func newTodayCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "today",
-		Short: "List tasks scheduled for today",
+		Short: "List todos scheduled for today",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := things3.NewClient()
 			if err != nil {
@@ -63,11 +65,47 @@ func newTodayCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			tasks, err := client.Today(cmd.Context())
+			ctx := cmd.Context()
+
+			// Regular Today tasks: have a start date and in Anytime bucket
+			regularTodos, err := client.Todos().
+				StartDate().Exists(true).
+				Start().Anytime().
+				Status().Incomplete().
+				OrderByTodayIndex().
+				All(ctx)
 			if err != nil {
 				return err
 			}
-			return outputTasks(cmd, tasks)
+
+			// Scheduled tasks from Someday with past start dates (yellow dot)
+			scheduledTodos, err := client.Todos().
+				StartDate().Past().
+				Start().Someday().
+				Status().Incomplete().
+				OrderByTodayIndex().
+				All(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Overdue deadline tasks: no start date, deadline past, not suppressed
+			overdueTodos, err := client.Todos().
+				StartDate().Exists(false).
+				Deadline().Past().
+				DeadlineSuppressed(false).
+				Status().Incomplete().
+				All(ctx)
+			if err != nil {
+				return err
+			}
+
+			todos := make([]things3.Todo, 0, len(regularTodos)+len(scheduledTodos)+len(overdueTodos))
+			todos = append(todos, regularTodos...)
+			todos = append(todos, scheduledTodos...)
+			todos = append(todos, overdueTodos...)
+
+			return outputTodos(cmd, todos)
 		},
 	}
 }
@@ -75,7 +113,7 @@ func newTodayCmd() *cobra.Command {
 func newUpcomingCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "upcoming",
-		Short: "List tasks scheduled for future dates",
+		Short: "List todos scheduled for future dates",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := things3.NewClient()
 			if err != nil {
@@ -83,11 +121,15 @@ func newUpcomingCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			tasks, err := client.Upcoming(cmd.Context())
+			todos, err := client.Todos().
+				StartDate().Future().
+				Start().Someday().
+				Status().Incomplete().
+				All(cmd.Context())
 			if err != nil {
 				return err
 			}
-			return outputTasks(cmd, tasks)
+			return outputTodos(cmd, todos)
 		},
 	}
 }
@@ -95,7 +137,7 @@ func newUpcomingCmd() *cobra.Command {
 func newAnytimeCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "anytime",
-		Short: "List tasks in the Anytime list",
+		Short: "List todos in the Anytime list",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := things3.NewClient()
 			if err != nil {
@@ -103,11 +145,14 @@ func newAnytimeCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			tasks, err := client.Anytime(cmd.Context())
+			todos, err := client.Todos().
+				Start().Anytime().
+				Status().Incomplete().
+				All(cmd.Context())
 			if err != nil {
 				return err
 			}
-			return outputTasks(cmd, tasks)
+			return outputTodos(cmd, todos)
 		},
 	}
 }
@@ -115,7 +160,7 @@ func newAnytimeCmd() *cobra.Command {
 func newSomedayCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "someday",
-		Short: "List tasks in the Someday list",
+		Short: "List todos in the Someday list",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := things3.NewClient()
 			if err != nil {
@@ -123,11 +168,15 @@ func newSomedayCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			tasks, err := client.Someday(cmd.Context())
+			todos, err := client.Todos().
+				StartDate().Exists(false).
+				Start().Someday().
+				Status().Incomplete().
+				All(cmd.Context())
 			if err != nil {
 				return err
 			}
-			return outputTasks(cmd, tasks)
+			return outputTodos(cmd, todos)
 		},
 	}
 }
@@ -135,7 +184,7 @@ func newSomedayCmd() *cobra.Command {
 func newLogbookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logbook",
-		Short: "List completed and canceled tasks",
+		Short: "List completed and canceled todos",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := things3.NewClient()
 			if err != nil {
@@ -145,24 +194,20 @@ func newLogbookCmd() *cobra.Command {
 
 			days, _ := cmd.Flags().GetInt("days")
 
-			var tasks []things3.Task
-			if days == 0 {
-				// No limit, get all
-				tasks, err = client.Logbook(cmd.Context())
-			} else {
-				// Filter by stop date within N days
+			q := client.Todos().
+				Status().Any().
+				StopDate().Exists(true)
+
+			if days > 0 {
 				since := time.Now().AddDate(0, 0, -days)
-				tasks, err = client.Tasks().
-					StopDate().After(since).
-					Status().Any().
-					ContextTrashed(false).
-					All(cmd.Context())
+				q = q.StopDate().After(since)
 			}
+
+			todos, err := q.All(cmd.Context())
 			if err != nil {
 				return err
 			}
-
-			return outputTasks(cmd, tasks)
+			return outputTodos(cmd, todos)
 		},
 	}
 
@@ -174,7 +219,7 @@ func newLogbookCmd() *cobra.Command {
 func newDeadlinesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "deadlines",
-		Short: "List tasks with deadlines",
+		Short: "List todos with deadlines",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := things3.NewClient()
 			if err != nil {
@@ -182,11 +227,14 @@ func newDeadlinesCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			tasks, err := client.Deadlines(cmd.Context())
+			todos, err := client.Todos().
+				Deadline().Exists(true).
+				Status().Incomplete().
+				All(cmd.Context())
 			if err != nil {
 				return err
 			}
-			return outputTasks(cmd, tasks)
+			return outputTodos(cmd, todos)
 		},
 	}
 }
@@ -202,11 +250,13 @@ func newProjectsCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			tasks, err := client.Projects(cmd.Context())
+			projects, err := client.Projects().
+				Status().Incomplete().
+				All(cmd.Context())
 			if err != nil {
 				return err
 			}
-			return outputTasks(cmd, tasks)
+			return outputProjects(cmd, projects)
 		},
 	}
 }

--- a/cmd/things3/cmd/output.go
+++ b/cmd/things3/cmd/output.go
@@ -32,7 +32,7 @@ func getOutputFlags(cmd *cobra.Command) (limit int, format outputFormat) {
 	return limit, formatText
 }
 
-// applyLimit applies the limit to a slice of tasks.
+// applyLimit applies the limit to a slice.
 func applyLimit[T any](items []T, limit int) []T {
 	if limit > 0 && len(items) > limit {
 		return items[:limit]
@@ -40,11 +40,18 @@ func applyLimit[T any](items []T, limit int) []T {
 	return items
 }
 
-// outputTasks formats and outputs tasks based on the command flags.
-func outputTasks(cmd *cobra.Command, tasks []things3.Task) error {
+// outputTodos formats and outputs todos based on the command flags.
+func outputTodos(cmd *cobra.Command, todos []things3.Todo) error {
 	limit, format := getOutputFlags(cmd)
-	tasks = applyLimit(tasks, limit)
-	return writeTasks(cmd.OutOrStdout(), tasks, format)
+	todos = applyLimit(todos, limit)
+	return writeTodos(cmd.OutOrStdout(), todos, format)
+}
+
+// outputProjects formats and outputs projects based on the command flags.
+func outputProjects(cmd *cobra.Command, projects []things3.Project) error {
+	limit, format := getOutputFlags(cmd)
+	projects = applyLimit(projects, limit)
+	return writeProjects(cmd.OutOrStdout(), projects, format)
 }
 
 // outputAreas formats and outputs areas based on the command flags.
@@ -61,22 +68,21 @@ func outputTags(cmd *cobra.Command, tags []things3.Tag) error {
 	return writeTags(cmd.OutOrStdout(), tags, format)
 }
 
-// writeTasks writes tasks to the writer in the specified format.
-func writeTasks(w io.Writer, tasks []things3.Task, format outputFormat) error {
+// writeTodos writes todos to the writer in the specified format.
+func writeTodos(w io.Writer, todos []things3.Todo, format outputFormat) error {
 	switch format {
 	case formatJSON:
-		return writeJSON(w, tasks)
+		return writeJSON(w, todos)
 	case formatYAML:
-		return writeYAML(w, tasks)
+		return writeYAML(w, todos)
 	default:
-		// Print header
-		if len(tasks) > 0 {
-			if _, err := fmt.Fprintln(w, "STATUS   UUID      TYPE     TITLE"); err != nil {
+		if len(todos) > 0 {
+			if _, err := fmt.Fprintln(w, "STATUS   UUID      TITLE"); err != nil {
 				return err
 			}
 		}
-		for i := range tasks {
-			if _, err := fmt.Fprintln(w, formatTaskLine(&tasks[i])); err != nil {
+		for i := range todos {
+			if _, err := fmt.Fprintln(w, formatTodoLine(&todos[i])); err != nil {
 				return err
 			}
 		}
@@ -84,35 +90,63 @@ func writeTasks(w io.Writer, tasks []things3.Task, format outputFormat) error {
 	}
 }
 
-// formatTaskLine formats a single task as a compact one-line string.
-// Format: [x] UUID type Title | date | #tag1 #tag2
-func formatTaskLine(t *things3.Task) string {
-	// Status checkbox
-	checkbox := "[ ]"
-	switch t.Status {
-	case things3.StatusCompleted:
-		checkbox = "[x]"
-	case things3.StatusCanceled:
-		checkbox = "[-]"
+// writeProjects writes projects to the writer in the specified format.
+func writeProjects(w io.Writer, projects []things3.Project, format outputFormat) error {
+	switch format {
+	case formatJSON:
+		return writeJSON(w, projects)
+	case formatYAML:
+		return writeYAML(w, projects)
+	default:
+		if len(projects) > 0 {
+			if _, err := fmt.Fprintln(w, "STATUS   UUID      TITLE"); err != nil {
+				return err
+			}
+		}
+		for i := range projects {
+			if _, err := fmt.Fprintln(w, formatProjectLine(&projects[i])); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
+}
 
-	// Task type
-	taskType := formatTaskType(t.Type)
+// formatTodoLine formats a single todo as a compact one-line string.
+func formatTodoLine(t *things3.Todo) string {
+	checkbox := statusCheckbox(t.Status)
+	line := fmt.Sprintf("%-8s %-9s %s", checkbox, shortUUID(t.UUID), t.Title)
 
-	// Build the line: [x] UUID type Title
-	line := fmt.Sprintf("%-8s %-9s %-8s %s", checkbox, shortUUID(t.UUID), taskType, t.Title)
-
-	// Add date (prefer stop_date > deadline > start_date)
-	if date := getRelevantDate(t); date != "" {
+	if date := todoRelevantDate(t); date != "" {
 		line += " | " + date
 	}
-
-	// Add tags
 	if tags := formatTags(t.Tags); tags != "" {
 		line += " | " + tags
 	}
-
 	return line
+}
+
+// formatProjectLine formats a single project as a compact one-line string.
+func formatProjectLine(p *things3.Project) string {
+	checkbox := statusCheckbox(p.Status)
+	line := fmt.Sprintf("%-8s %-9s %s", checkbox, shortUUID(p.UUID), p.Title)
+
+	if date := projectRelevantDate(p); date != "" {
+		line += " | " + date
+	}
+	return line
+}
+
+// statusCheckbox returns a checkbox string for the given status.
+func statusCheckbox(s things3.Status) string {
+	switch s {
+	case things3.StatusCompleted:
+		return "[x]"
+	case things3.StatusCanceled:
+		return "[-]"
+	default:
+		return "[ ]"
+	}
 }
 
 // shortUUID returns the first 8 characters of a UUID for display.
@@ -123,31 +157,35 @@ func shortUUID(uuid string) string {
 	return uuid
 }
 
-// formatTaskType returns a short string representation of the task type.
-func formatTaskType(t things3.TaskType) string {
-	switch t {
-	case things3.TaskTypeTodo:
-		return "todo"
-	case things3.TaskTypeProject:
-		return "project"
-	case things3.TaskTypeHeading:
-		return "heading"
-	default:
-		return "unknown"
-	}
-}
-
-// getRelevantDate returns the most relevant date for display.
-func getRelevantDate(t *things3.Task) string {
+// todoRelevantDate returns the most relevant date for display.
+func todoRelevantDate(t *things3.Todo) string {
 	const dateFormat = "2006-01-02"
-	if t.StopDate != nil {
-		return t.StopDate.Format(dateFormat)
+	if t.CompletedAt != nil {
+		return t.CompletedAt.Format(dateFormat)
+	}
+	if t.CanceledAt != nil {
+		return t.CanceledAt.Format(dateFormat)
 	}
 	if t.Deadline != nil {
 		return "due:" + t.Deadline.Format(dateFormat)
 	}
 	if t.StartDate != nil {
 		return t.StartDate.Format(dateFormat)
+	}
+	return ""
+}
+
+// projectRelevantDate returns the most relevant date for display.
+func projectRelevantDate(p *things3.Project) string {
+	const dateFormat = "2006-01-02"
+	if p.CompletedAt != nil {
+		return p.CompletedAt.Format(dateFormat)
+	}
+	if p.CanceledAt != nil {
+		return p.CanceledAt.Format(dateFormat)
+	}
+	if p.Deadline != nil {
+		return "due:" + p.Deadline.Format(dateFormat)
 	}
 	return ""
 }
@@ -199,6 +237,114 @@ func writeTags(w io.Writer, tags []things3.Tag, format outputFormat) error {
 		}
 		return nil
 	}
+}
+
+// outputTodoDetail formats and outputs a single todo with full details.
+func outputTodoDetail(cmd *cobra.Command, todo *things3.Todo) error {
+	_, format := getOutputFlags(cmd)
+	if format == formatJSON {
+		return writeJSON(cmd.OutOrStdout(), todo)
+	}
+	if format == formatYAML {
+		return writeYAML(cmd.OutOrStdout(), todo)
+	}
+	return writeTodoDetail(cmd.OutOrStdout(), todo)
+}
+
+// outputProjectDetail formats and outputs a single project with full details and its todos.
+func outputProjectDetail(cmd *cobra.Command, project *things3.Project, todos []things3.Todo) error {
+	_, format := getOutputFlags(cmd)
+	w := cmd.OutOrStdout()
+	if format == formatJSON {
+		return writeJSON(w, project)
+	}
+	if format == formatYAML {
+		return writeYAML(w, project)
+	}
+	if err := writeProjectDetail(w, project); err != nil {
+		return err
+	}
+	if len(todos) > 0 {
+		fmt.Fprintln(w)
+		return writeTodos(w, todos, formatText)
+	}
+	return nil
+}
+
+// writeTodoDetail writes a single todo with full details in text format.
+func writeTodoDetail(w io.Writer, t *things3.Todo) error {
+	const dateFormat = "2006-01-02"
+	fmt.Fprintf(w, "Title:    %s\n", t.Title)
+	fmt.Fprintf(w, "UUID:     %s\n", t.UUID)
+	fmt.Fprintf(w, "Status:   %s\n", t.Status)
+	fmt.Fprintf(w, "Start:    %s\n", t.Start)
+
+	if t.ProjectTitle != "" {
+		fmt.Fprintf(w, "Project:  %s\n", t.ProjectTitle)
+	}
+	if t.AreaTitle != "" {
+		fmt.Fprintf(w, "Area:     %s\n", t.AreaTitle)
+	}
+	if t.HeadingTitle != "" {
+		fmt.Fprintf(w, "Heading:  %s\n", t.HeadingTitle)
+	}
+	if len(t.Tags) > 0 {
+		fmt.Fprintf(w, "Tags:     %s\n", formatTags(t.Tags))
+	}
+	if t.StartDate != nil {
+		fmt.Fprintf(w, "When:     %s\n", t.StartDate.Format(dateFormat))
+	}
+	if t.Deadline != nil {
+		fmt.Fprintf(w, "Deadline: %s\n", t.Deadline.Format(dateFormat))
+	}
+	if t.CompletedAt != nil {
+		fmt.Fprintf(w, "Done:     %s\n", t.CompletedAt.Format(dateFormat))
+	}
+	if t.CanceledAt != nil {
+		fmt.Fprintf(w, "Canceled: %s\n", t.CanceledAt.Format(dateFormat))
+	}
+	if t.Notes != "" {
+		fmt.Fprintf(w, "\nNotes:\n%s\n", t.Notes)
+	}
+	if len(t.Checklist) > 0 {
+		fmt.Fprintln(w, "\nChecklist:")
+		for i := range t.Checklist {
+			fmt.Fprintf(w, "  %s %s\n", statusCheckbox(t.Checklist[i].Status), t.Checklist[i].Title)
+		}
+	}
+	return nil
+}
+
+// writeProjectDetail writes a single project with full details in text format.
+func writeProjectDetail(w io.Writer, p *things3.Project) error {
+	const dateFormat = "2006-01-02"
+	fmt.Fprintf(w, "Title:    %s\n", p.Title)
+	fmt.Fprintf(w, "UUID:     %s\n", p.UUID)
+	fmt.Fprintf(w, "Status:   %s\n", p.Status)
+	fmt.Fprintf(w, "Start:    %s\n", p.Start)
+
+	if p.AreaTitle != "" {
+		fmt.Fprintf(w, "Area:     %s\n", p.AreaTitle)
+	}
+	if len(p.Tags) > 0 {
+		fmt.Fprintf(w, "Tags:     %s\n", formatTags(p.Tags))
+	}
+	if p.StartDate != nil {
+		fmt.Fprintf(w, "When:     %s\n", p.StartDate.Format(dateFormat))
+	}
+	if p.Deadline != nil {
+		fmt.Fprintf(w, "Deadline: %s\n", p.Deadline.Format(dateFormat))
+	}
+	if p.CompletedAt != nil {
+		fmt.Fprintf(w, "Done:     %s\n", p.CompletedAt.Format(dateFormat))
+	}
+	if p.CanceledAt != nil {
+		fmt.Fprintf(w, "Canceled: %s\n", p.CanceledAt.Format(dateFormat))
+	}
+	if p.Notes != "" {
+		fmt.Fprintf(w, "\nNotes:\n%s\n", p.Notes)
+	}
+	return nil
 }
 
 // writeJSON writes any value as JSON to the writer.

--- a/cmd/things3/cmd/output.go
+++ b/cmd/things3/cmd/output.go
@@ -187,6 +187,9 @@ func projectRelevantDate(p *things3.Project) string {
 	if p.Deadline != nil {
 		return "due:" + p.Deadline.Format(dateFormat)
 	}
+	if p.StartDate != nil {
+		return p.StartDate.Format(dateFormat)
+	}
 	return ""
 }
 
@@ -251,15 +254,21 @@ func outputTodoDetail(cmd *cobra.Command, todo *things3.Todo) error {
 	return writeTodoDetail(cmd.OutOrStdout(), todo)
 }
 
+// projectDetailOutput is the structured representation for JSON/YAML output.
+type projectDetailOutput struct {
+	Project *things3.Project `json:"project" yaml:"project"`
+	Todos   []things3.Todo   `json:"todos,omitempty" yaml:"todos,omitempty"`
+}
+
 // outputProjectDetail formats and outputs a single project with full details and its todos.
 func outputProjectDetail(cmd *cobra.Command, project *things3.Project, todos []things3.Todo) error {
 	_, format := getOutputFlags(cmd)
 	w := cmd.OutOrStdout()
 	if format == formatJSON {
-		return writeJSON(w, project)
+		return writeJSON(w, projectDetailOutput{Project: project, Todos: todos})
 	}
 	if format == formatYAML {
-		return writeYAML(w, project)
+		return writeYAML(w, projectDetailOutput{Project: project, Todos: todos})
 	}
 	if err := writeProjectDetail(w, project); err != nil {
 		return err

--- a/cmd/things3/cmd/project.go
+++ b/cmd/things3/cmd/project.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/moond4rk/things3"
+)
+
+// NewProjectCmd creates the project command for viewing a single project.
+func NewProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project <uuid-prefix>",
+		Short: "Show a project by UUID prefix or title",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := things3.NewClient()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			identifier := args[0]
+			byTitle, _ := cmd.Flags().GetBool("title")
+			bySearch, _ := cmd.Flags().GetBool("search")
+
+			var q things3.ProjectQueryBuilder
+			switch {
+			case byTitle:
+				q = client.Projects().WithTitle(identifier).Status().Any()
+			case bySearch:
+				q = client.Projects().Search(identifier).Status().Any()
+			default:
+				// Projects don't have WithUUIDPrefix, use WithUUID for exact match
+				q = client.Projects().WithUUID(identifier).Status().Any()
+			}
+
+			projects, err := q.All(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			if len(projects) == 1 {
+				todos, err := client.Todos().
+					InProject(projects[0].UUID).
+					Status().Incomplete().
+					All(cmd.Context())
+				if err != nil {
+					return err
+				}
+				return outputProjectDetail(cmd, &projects[0], todos)
+			}
+			return outputProjects(cmd, projects)
+		},
+	}
+
+	cmd.Flags().BoolP("title", "t", false, "match by exact title")
+	cmd.Flags().BoolP("search", "s", false, "search in title, notes, and area")
+
+	return cmd
+}

--- a/cmd/things3/cmd/project.go
+++ b/cmd/things3/cmd/project.go
@@ -9,8 +9,8 @@ import (
 // NewProjectCmd creates the project command for viewing a single project.
 func NewProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "project <uuid-prefix>",
-		Short: "Show a project by UUID prefix or title",
+		Use:   "project <identifier>",
+		Short: "Show a project by UUID, title keyword, or search query",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := things3.NewClient()
@@ -30,7 +30,6 @@ func NewProjectCmd() *cobra.Command {
 			case bySearch:
 				q = client.Projects().Search(identifier).Status().Any()
 			default:
-				// Projects don't have WithUUIDPrefix, use WithUUID for exact match
 				q = client.Projects().WithUUID(identifier).Status().Any()
 			}
 
@@ -53,7 +52,7 @@ func NewProjectCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolP("title", "t", false, "match by exact title")
+	cmd.Flags().BoolP("title", "t", false, "match by title keyword")
 	cmd.Flags().BoolP("search", "s", false, "search in title, notes, and area")
 
 	return cmd

--- a/cmd/things3/cmd/project.go
+++ b/cmd/things3/cmd/project.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/moond4rk/things3"
@@ -22,6 +24,10 @@ func NewProjectCmd() *cobra.Command {
 			identifier := args[0]
 			byTitle, _ := cmd.Flags().GetBool("title")
 			bySearch, _ := cmd.Flags().GetBool("search")
+
+			if byTitle && bySearch {
+				return fmt.Errorf("--title and --search are mutually exclusive")
+			}
 
 			var q things3.ProjectQueryBuilder
 			switch {

--- a/cmd/things3/cmd/root.go
+++ b/cmd/things3/cmd/root.go
@@ -35,6 +35,8 @@ query tasks, projects, areas, and tags from the command line.`,
 	cmd.AddCommand(NewVersionCmd())
 	cmd.AddCommand(NewListCmd())
 	cmd.AddCommand(NewSearchCmd())
+	cmd.AddCommand(NewTodoCmd())
+	cmd.AddCommand(NewProjectCmd())
 
 	return cmd
 }

--- a/cmd/things3/cmd/search.go
+++ b/cmd/things3/cmd/search.go
@@ -10,7 +10,7 @@ import (
 func NewSearchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>",
-		Short: "Search for todos by title or UUID prefix",
+		Short: "Search for todos by title, notes, and area",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := things3.NewClient()

--- a/cmd/things3/cmd/search.go
+++ b/cmd/things3/cmd/search.go
@@ -10,7 +10,7 @@ import (
 func NewSearchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>",
-		Short: "Search for tasks by title or UUID prefix",
+		Short: "Search for todos by title or UUID prefix",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := things3.NewClient()
@@ -22,22 +22,18 @@ func NewSearchCmd() *cobra.Command {
 			query := args[0]
 			byUUID, _ := cmd.Flags().GetBool("uuid")
 
-			var tasks []things3.Task
+			var q things3.TodoQueryBuilder
 			if byUUID {
-				// Search by UUID prefix
-				tasks, err = client.Tasks().
-					WithUUIDPrefix(query).
-					Status().Any().
-					All(cmd.Context())
+				q = client.Todos().WithUUIDPrefix(query).Status().Any()
 			} else {
-				// Search by title/notes
-				tasks, err = client.Search(cmd.Context(), query)
+				q = client.Todos().Search(query).Status().Any()
 			}
+
+			todos, err := q.All(cmd.Context())
 			if err != nil {
 				return err
 			}
-
-			return outputTasks(cmd, tasks)
+			return outputTodos(cmd, todos)
 		},
 	}
 

--- a/cmd/things3/cmd/todo.go
+++ b/cmd/things3/cmd/todo.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/moond4rk/things3"
@@ -22,6 +24,10 @@ func NewTodoCmd() *cobra.Command {
 			identifier := args[0]
 			byTitle, _ := cmd.Flags().GetBool("title")
 			bySearch, _ := cmd.Flags().GetBool("search")
+
+			if byTitle && bySearch {
+				return fmt.Errorf("--title and --search are mutually exclusive")
+			}
 
 			var q things3.TodoQueryBuilder
 			switch {

--- a/cmd/things3/cmd/todo.go
+++ b/cmd/things3/cmd/todo.go
@@ -9,8 +9,8 @@ import (
 // NewTodoCmd creates the todo command for viewing a single todo.
 func NewTodoCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "todo <uuid-prefix>",
-		Short: "Show a todo by UUID prefix or title",
+		Use:   "todo <identifier>",
+		Short: "Show a todo by UUID prefix, title keyword, or search query",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := things3.NewClient()
@@ -33,7 +33,7 @@ func NewTodoCmd() *cobra.Command {
 				q = client.Todos().WithUUIDPrefix(identifier).Status().Any()
 			}
 
-			todos, err := q.All(cmd.Context())
+			todos, err := q.IncludeChecklist().All(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -45,7 +45,7 @@ func NewTodoCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolP("title", "t", false, "match by exact title")
+	cmd.Flags().BoolP("title", "t", false, "match by title keyword")
 	cmd.Flags().BoolP("search", "s", false, "search in title, notes, and area")
 
 	return cmd

--- a/cmd/things3/cmd/todo.go
+++ b/cmd/things3/cmd/todo.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/moond4rk/things3"
+)
+
+// NewTodoCmd creates the todo command for viewing a single todo.
+func NewTodoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "todo <uuid-prefix>",
+		Short: "Show a todo by UUID prefix or title",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := things3.NewClient()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			identifier := args[0]
+			byTitle, _ := cmd.Flags().GetBool("title")
+			bySearch, _ := cmd.Flags().GetBool("search")
+
+			var q things3.TodoQueryBuilder
+			switch {
+			case byTitle:
+				q = client.Todos().WithTitle(identifier).Status().Any()
+			case bySearch:
+				q = client.Todos().Search(identifier).Status().Any()
+			default:
+				q = client.Todos().WithUUIDPrefix(identifier).Status().Any()
+			}
+
+			todos, err := q.All(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			if len(todos) == 1 {
+				return outputTodoDetail(cmd, &todos[0])
+			}
+			return outputTodos(cmd, todos)
+		},
+	}
+
+	cmd.Flags().BoolP("title", "t", false, "match by exact title")
+	cmd.Flags().BoolP("search", "s", false, "search in title, notes, and area")
+
+	return cmd
+}

--- a/rfcs/010_rfc_cli_design.md
+++ b/rfcs/010_rfc_cli_design.md
@@ -27,11 +27,11 @@ things3
 |   +-- areas
 |   +-- tags
 |
-+-- todo <identifier>    (View todo by UUID prefix, title, or search)
++-- todo <identifier>    (View todo by UUID prefix, title keyword, or search)
 |   --title/-t           (Match by title keyword)
 |   --search/-s          (Search title + notes + area)
 |
-+-- project <identifier> (View project by UUID, title, or search)
++-- project <identifier> (View project by UUID, title keyword, or search)
 |   --title/-t           (Match by title keyword)
 |   --search/-s          (Search title + notes + area)
 |
@@ -71,7 +71,8 @@ Results are concatenated in order: regular, scheduled, overdue.
 ### Detail Commands (todo, project)
 
 Identifier resolution strategy:
-- Default: UUID prefix match via `WithUUIDPrefix()`
+- Default (todo): UUID prefix match via `WithUUIDPrefix()`
+- Default (project): Exact UUID match via `WithUUID()`
 - `--title/-t`: Title keyword match via `WithTitle()` (LIKE `%keyword%`)
 - `--search/-s`: Full-text search via `Search()` (title + notes + area)
 

--- a/rfcs/010_rfc_cli_design.md
+++ b/rfcs/010_rfc_cli_design.md
@@ -1,0 +1,121 @@
+# RFC 010: CLI Design
+
+Status: Draft
+Author: @moond4rk
+Date: 2026-03-09
+
+## Summary
+
+Design specification for the `things3` CLI tool. The CLI provides command-line access to Things 3 data using the typed query builder API from RFC 009. It supports read operations across all domain types with flexible output formats.
+
+## Architecture
+
+The CLI uses Cobra with factory function pattern (no `init()`). All commands return errors and let `main()` handle `os.Exit()`.
+
+```
+things3
+|
++-- list <view>          (List todos/projects/areas/tags by view)
+|   +-- inbox
+|   +-- today            (Three-query composition)
+|   +-- upcoming
+|   +-- anytime
+|   +-- someday
+|   +-- logbook           --days/-d (default: 30)
+|   +-- deadlines
+|   +-- projects
+|   +-- areas
+|   +-- tags
+|
++-- todo <identifier>    (View todo by UUID prefix, title, or search)
+|   --title/-t           (Match by title keyword)
+|   --search/-s          (Search title + notes + area)
+|
++-- project <identifier> (View project by UUID, title, or search)
+|   --title/-t           (Match by title keyword)
+|   --search/-s          (Search title + notes + area)
+|
++-- search <query>       (Search todos by title/notes/area)
+|   --uuid/-u            (Search by UUID prefix instead)
+|
++-- version              (Show version)
+|
+Global flags:
+  --limit/-n             (Max items to display, 0=unlimited)
+  --json/-j              (Output as JSON)
+  --yaml/-y              (Output as YAML)
+```
+
+## Command Design
+
+### List Commands
+
+Each list subcommand maps directly to a query builder chain. Key design decisions:
+
+**Default filters**: All queries automatically exclude trashed items and items in trashed projects (parent-trashed exclusion is a default behavior in the database layer, not an explicit filter).
+
+**Today view** is the most complex, composed of three separate queries:
+
+1. Regular Today tasks: `StartDate().Exists(true)` + `Start().Anytime()` + `Status().Incomplete()`
+2. Yellow dot tasks: `StartDate().Past()` + `Start().Someday()` + `Status().Incomplete()`
+3. Overdue deadline tasks: `StartDate().Exists(false)` + `Deadline().Past()` + `DeadlineSuppressed(false)` + `Status().Incomplete()`
+
+Results are concatenated in order: regular, scheduled, overdue.
+
+**Upcoming** uses `Start().Someday()` (not Anytime) with `StartDate().Future()`.
+
+**Someday** uses `StartDate().Exists(false)` to exclude tasks with scheduled dates.
+
+**Logbook** defaults to 30 days via `--days` flag, uses `StopDate().Exists(true)` + `Status().Any()`.
+
+### Detail Commands (todo, project)
+
+Identifier resolution strategy:
+- Default: UUID prefix match via `WithUUIDPrefix()`
+- `--title/-t`: Title keyword match via `WithTitle()` (LIKE `%keyword%`)
+- `--search/-s`: Full-text search via `Search()` (title + notes + area)
+
+All modes use `Status().Any()` to include completed/canceled items.
+
+Display behavior:
+- 1 result: Show detailed view (all fields, checklist for todos, incomplete todos for projects)
+- Multiple results: Show compact list view (same format as list commands)
+- 0 results: No output
+
+### Output Formats
+
+Three output modes controlled by global flags:
+
+| Format | Flag | Description |
+|--------|------|-------------|
+| Text | (default) | Compact one-line format with status checkbox and short UUID |
+| JSON | `--json` | Full structured output via `json.Encoder` |
+| YAML | `--yaml` | Full structured output via `yaml.Marshal` |
+
+Text format columns: `STATUS UUID TITLE [| date] [| #tags]`
+
+Detail text view shows all fields vertically (Title, UUID, Status, Start, Project, Area, Tags, When, Deadline, Notes, Checklist).
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `cmd/things3/main.go` | Entry point, calls `NewRootCmd().Execute()` |
+| `cmd/things3/cmd/root.go` | Root command, global flags, subcommand registration |
+| `cmd/things3/cmd/list.go` | List subcommands (inbox, today, upcoming, etc.) |
+| `cmd/things3/cmd/todo.go` | Single todo lookup command |
+| `cmd/things3/cmd/project.go` | Single project lookup command |
+| `cmd/things3/cmd/search.go` | Search command |
+| `cmd/things3/cmd/output.go` | Output formatting (text, JSON, YAML) |
+| `cmd/things3/cmd/version.go` | Version command |
+
+## Future Considerations
+
+Potential commands not yet implemented:
+
+- **Add**: `things3 add todo --title "..." --when today` via `client.AddTodo()`
+- **Update**: `things3 update todo <uuid> --completed` via `client.UpdateTodo()`
+- **Show/Open**: `things3 open <uuid>` via `client.Show()` to open in Things app
+- **Trash**: `things3 list trash` for viewing trashed items
+- **Headings**: `things3 list headings --project <uuid>` for project headings
+- **Today convenience method**: `client.Today(ctx)` on Client to encapsulate the three-query Today logic, removing the need to expose `DeadlineSuppressed` on the public API


### PR DESCRIPTION
Close #49 

## Summary

- Add `todo` command with UUID prefix (default), `--title`, and `--search` lookup modes
- Add `project` command with detail view that shows incomplete child todos
- Fix `list today` to use three-query composition (regular + yellow dot + overdue deadline)
- Fix `list upcoming` to use `Start().Someday()` instead of `Anytime()`
- Fix `list someday` to exclude tasks with scheduled dates
- Add detail text output for single todo/project views (title, UUID, status, dates, notes, checklist)
- Add RFC 010 documenting CLI design

## Test plan

- [x] Verify `things3 list today` returns correct tasks (regular + yellow dot + overdue)
- [x] Verify `things3 list upcoming/someday/inbox/anytime` match Things 3 app behavior
- [x] Verify `things3 todo <uuid-prefix>` shows detail view for single match, list for multiple
- [x] Verify `things3 todo -t <keyword>` searches by title keyword
- [ ] Verify `things3 project <uuid>` shows project detail with incomplete child todos
- [ ] Verify `--json` and `--yaml` flags work with detail commands
- [ ] Run `golangci-lint run` with no issues