### PR TITLE
fix: resolve confirmed audit findings across all layers

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -227,9 +227,20 @@ func TestAddTodoBuilder_Titles(t *testing.T) {
 
 func TestAddTodoBuilder_TitlesTooLong(t *testing.T) {
 	scheme := newScheme()
-	longTitle := strings.Repeat("a", 2000)
-	_, err := scheme.AddTodo().Titles(longTitle, longTitle, longTitle).Build()
+	longTitle := strings.Repeat("a", 4001)
+	_, err := scheme.AddTodo().Titles("short", longTitle).Build()
 	assert.ErrorIs(t, err, ErrTitleTooLong)
+}
+
+func TestAddTodoBuilder_TitlesLimitIsPerTitle(t *testing.T) {
+	// The per-title limit must not apply to the newline-joined combination.
+	scheme := newScheme()
+	title := strings.Repeat("a", 2500)
+	thingsURL, err := scheme.AddTodo().Titles(title, title).Build()
+	require.NoError(t, err)
+
+	_, params := parseThingsURL(t, thingsURL)
+	require.Equal(t, title+"\n"+title, params.Get("titles"))
 }
 
 func TestAddTodoBuilder_Heading(t *testing.T) {
@@ -1270,14 +1281,30 @@ func TestAuthBatchBuilder_Mixed(t *testing.T) {
 }
 
 func TestAuthBatchBuilder_EmptyToken(t *testing.T) {
+	// A batch containing an update still fails without a token.
 	scheme := newScheme()
 	auth := scheme.WithToken("")
 	_, err := auth.Batch().
-		AddTodo(func(todo BatchTodoConfigurator) {
+		UpdateTodo("uuid", func(todo BatchTodoConfigurator) {
 			todo.Title("Test")
 		}).
 		Build()
 	assert.ErrorIs(t, err, ErrEmptyToken)
+}
+
+func TestAuthBatchBuilder_CreateOnlyNeedsNoToken(t *testing.T) {
+	// Create-only batches never emit auth-token, so an empty token must not fail.
+	scheme := newScheme()
+	auth := scheme.WithToken("")
+	thingsURL, err := auth.Batch().
+		AddTodo(func(todo BatchTodoConfigurator) {
+			todo.Title("Test")
+		}).
+		Build()
+	require.NoError(t, err)
+
+	_, params := parseThingsURL(t, thingsURL)
+	require.False(t, params.Has("auth-token"))
 }
 
 func TestAuthBatchBuilder_NoItems(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -143,6 +143,14 @@ func (c *Client) ensureToken(ctx context.Context) (string, error) {
 		return "", err
 	}
 
+	// An empty stored token means URL scheme authorization was never enabled.
+	if token == "" {
+		return "", fmt.Errorf(
+			"%w: Things URL scheme authorization not set up (enable it in Things settings under General > Enable Things URLs)",
+			ErrAuthTokenNotFound,
+		)
+	}
+
 	// Cache successful result
 	c.tokenCache = token
 	return token, nil

--- a/client_test.go
+++ b/client_test.go
@@ -1,10 +1,13 @@
 package things3
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/moond4rk/things3/thingstest"
 )
 
 // newTestClient creates a new Client connected to the test database.
@@ -89,6 +92,27 @@ func TestClientToken(t *testing.T) {
 	token2, err := client.Token(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, token, token2)
+}
+
+func TestClientTokenEmptyInDatabase(t *testing.T) {
+	// An empty stored token means Things URL scheme authorization was never
+	// enabled; Token must fail with a descriptive error instead of returning
+	// the empty token as success.
+	dbPath := thingstest.DatabasePath(t)
+
+	raw, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = raw.ExecContext(t.Context(), "UPDATE TMSettings SET uriSchemeAuthenticationToken = ''")
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	client, err := NewClient(WithDatabasePath(dbPath))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	_, err = client.Token(t.Context())
+	require.ErrorIs(t, err, ErrAuthTokenNotFound)
+	assert.Contains(t, err.Error(), "authorization not set up")
 }
 
 func TestClientURLSchemeBuilders(t *testing.T) {

--- a/cmd/things3/cmd/cmd_test.go
+++ b/cmd/things3/cmd/cmd_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/moond4rk/things3/thingstest"
+)
+
+// setupFixtureDB points the CLI at a writable copy of the shared test fixture.
+func setupFixtureDB(t *testing.T) {
+	t.Helper()
+	t.Setenv("THINGSDB", thingstest.DatabasePath(t))
+}
+
+// executeCommand runs the root command with the given args and returns the
+// captured stdout, stderr, and execution error.
+func executeCommand(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	root := NewRootCmd()
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs(args)
+	err = root.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+func TestListInbox(t *testing.T) {
+	setupFixtureDB(t)
+
+	stdout, stderr, err := executeCommand(t, "list", "inbox")
+	if err != nil {
+		t.Fatalf("list inbox failed: %v (stderr: %s)", err, stderr)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if !strings.HasPrefix(lines[0], "STATUS") {
+		t.Errorf("expected header line, got %q", lines[0])
+	}
+	if got, want := len(lines)-1, thingstest.Inbox; got != want {
+		t.Errorf("expected %d inbox rows, got %d\noutput:\n%s", want, got, stdout)
+	}
+}
+
+func TestListInboxJSONArray(t *testing.T) {
+	setupFixtureDB(t)
+
+	stdout, stderr, err := executeCommand(t, "list", "inbox", "--json")
+	if err != nil {
+		t.Fatalf("list inbox --json failed: %v (stderr: %s)", err, stderr)
+	}
+
+	trimmed := strings.TrimSpace(stdout)
+	if !strings.HasPrefix(trimmed, "[") {
+		t.Errorf("expected JSON array output starting with [, got %q", trimmed)
+	}
+	var todos []map[string]any
+	if jsonErr := json.Unmarshal([]byte(trimmed), &todos); jsonErr != nil {
+		t.Fatalf("output is not a valid JSON array: %v", jsonErr)
+	}
+	if len(todos) != thingstest.Inbox {
+		t.Errorf("expected %d todos in JSON array, got %d", thingstest.Inbox, len(todos))
+	}
+}
+
+func TestProjectShortUUIDRoundTrip(t *testing.T) {
+	setupFixtureDB(t)
+
+	listOut, stderr, err := executeCommand(t, "list", "projects")
+	if err != nil {
+		t.Fatalf("list projects failed: %v (stderr: %s)", err, stderr)
+	}
+
+	lines := strings.Split(strings.TrimSpace(listOut), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected header plus at least one project row, got:\n%s", listOut)
+	}
+
+	// Row format is "%-8s %-9s %s" (status, short UUID, title): the displayed
+	// short UUID column starts at index 9.
+	firstRow := lines[1]
+	if len(firstRow) < 10 {
+		t.Fatalf("project row too short to contain a UUID column: %q", firstRow)
+	}
+	shortID := strings.Fields(firstRow[9:])[0]
+	if len(shortID) != 8 {
+		t.Fatalf("expected 8-char short UUID in list output, got %q from row %q", shortID, firstRow)
+	}
+
+	detailOut, stderr, err := executeCommand(t, "project", shortID)
+	if err != nil {
+		t.Fatalf("project %s failed: %v (stderr: %s)", shortID, err, stderr)
+	}
+	if !strings.Contains(detailOut, "Title:") {
+		t.Errorf("expected detail view with Title field, got:\n%s", detailOut)
+	}
+
+	var fullUUID string
+	for line := range strings.Lines(detailOut) {
+		if rest, ok := strings.CutPrefix(line, "UUID:"); ok {
+			fullUUID = strings.TrimSpace(rest)
+			break
+		}
+	}
+	if fullUUID == "" {
+		t.Fatalf("expected detail view with UUID field, got:\n%s", detailOut)
+	}
+	if !strings.HasPrefix(fullUUID, shortID) {
+		t.Errorf("detail UUID %q does not start with displayed short UUID %q", fullUUID, shortID)
+	}
+	if len(fullUUID) <= len(shortID) {
+		t.Errorf("expected full UUID longer than short form, got %q", fullUUID)
+	}
+}
+
+func TestCommandErrors(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		wantErrContains []string
+	}{
+		{
+			name:            "todo not found",
+			args:            []string{"todo", "zzznosuchtodo"},
+			wantErrContains: []string{"zzznosuchtodo"},
+		},
+		{
+			name:            "project not found",
+			args:            []string{"project", "zzznosuchproject"},
+			wantErrContains: []string{"zzznosuchproject"},
+		},
+		{
+			name:            "json and yaml are mutually exclusive",
+			args:            []string{"list", "inbox", "--json", "--yaml"},
+			wantErrContains: []string{"json", "yaml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupFixtureDB(t)
+
+			stdout, stderr, err := executeCommand(t, tt.args...)
+			if err == nil {
+				t.Fatalf("expected error for args %v, got nil", tt.args)
+			}
+			for _, want := range tt.wantErrContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err.Error(), want)
+				}
+				if !strings.Contains(stderr, want) {
+					t.Errorf("stderr %q does not contain %q", stderr, want)
+				}
+			}
+			if strings.Contains(stdout, "Usage:") || strings.Contains(stderr, "Usage:") {
+				t.Errorf("runtime error must not dump usage help\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+			}
+		})
+	}
+}
+
+// logbookRow captures the fields needed to verify logbook ordering.
+type logbookRow struct {
+	UUID        string     `json:"uuid"`
+	CompletedAt *time.Time `json:"completed_at"`
+	CanceledAt  *time.Time `json:"canceled_at"`
+}
+
+func (r *logbookRow) stopTime() *time.Time {
+	if r.CompletedAt != nil {
+		return r.CompletedAt
+	}
+	return r.CanceledAt
+}
+
+func runLogbookJSON(t *testing.T, args ...string) []logbookRow {
+	t.Helper()
+	stdout, stderr, err := executeCommand(t, append([]string{"list", "logbook", "--days", "0", "--json"}, args...)...)
+	if err != nil {
+		t.Fatalf("list logbook failed: %v (stderr: %s)", err, stderr)
+	}
+	var rows []logbookRow
+	if jsonErr := json.Unmarshal([]byte(stdout), &rows); jsonErr != nil {
+		t.Fatalf("cannot decode logbook JSON: %v", jsonErr)
+	}
+	return rows
+}
+
+func TestLogbookOrderedByStopTimeDesc(t *testing.T) {
+	setupFixtureDB(t)
+
+	rows := runLogbookJSON(t)
+	if len(rows) < 2 {
+		t.Fatalf("expected at least 2 logbook rows, got %d", len(rows))
+	}
+
+	for i := 1; i < len(rows); i++ {
+		prev, curr := rows[i-1].stopTime(), rows[i].stopTime()
+		if prev == nil {
+			if curr != nil {
+				t.Fatalf("row %d (%s) has a stop time but follows row %d (%s) without one",
+					i, rows[i].UUID, i-1, rows[i-1].UUID)
+			}
+			continue
+		}
+		if curr == nil {
+			continue
+		}
+		if curr.After(*prev) {
+			t.Fatalf("logbook not sorted by stop time descending: row %d (%s, %s) is more recent than row %d (%s, %s)",
+				i, rows[i].UUID, curr, i-1, rows[i-1].UUID, prev)
+		}
+	}
+
+	limited := runLogbookJSON(t, "--limit", "2")
+	if len(limited) != 2 {
+		t.Fatalf("expected 2 rows with --limit 2, got %d", len(limited))
+	}
+	for i := range limited {
+		if limited[i].UUID != rows[i].UUID {
+			t.Errorf("--limit 2 row %d = %s, want most recent entry %s", i, limited[i].UUID, rows[i].UUID)
+		}
+	}
+}

--- a/cmd/things3/cmd/list.go
+++ b/cmd/things3/cmd/list.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"slices"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -207,6 +208,7 @@ func newLogbookCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			sortByStopTimeDesc(todos)
 			return outputTodos(cmd, todos)
 		},
 	}
@@ -214,6 +216,33 @@ func newLogbookCmd() *cobra.Command {
 	cmd.Flags().IntP("days", "d", 30, "limit to recent N days (0 for all)")
 
 	return cmd
+}
+
+// stopTime returns when a todo left the active list: completion time if set,
+// otherwise cancellation time, otherwise nil.
+func stopTime(t *things3.Todo) *time.Time {
+	if t.CompletedAt != nil {
+		return t.CompletedAt
+	}
+	return t.CanceledAt
+}
+
+// sortByStopTimeDesc orders todos by stop time descending so that --limit N
+// yields the N most recent entries. Todos without a stop time sort last.
+func sortByStopTimeDesc(todos []things3.Todo) {
+	slices.SortStableFunc(todos, func(a, b things3.Todo) int {
+		ta, tb := stopTime(&a), stopTime(&b)
+		switch {
+		case ta == nil && tb == nil:
+			return 0
+		case ta == nil:
+			return 1
+		case tb == nil:
+			return -1
+		default:
+			return tb.Compare(*ta)
+		}
+	})
 }
 
 func newDeadlinesCmd() *cobra.Command {

--- a/cmd/things3/cmd/project.go
+++ b/cmd/things3/cmd/project.go
@@ -12,7 +12,7 @@ import (
 func NewProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project <identifier>",
-		Short: "Show a project by UUID, title keyword, or search query",
+		Short: "Show a project by UUID prefix, title keyword, or search query",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := things3.NewClient()
@@ -36,7 +36,7 @@ func NewProjectCmd() *cobra.Command {
 			case bySearch:
 				q = client.Projects().Search(identifier).Status().Any()
 			default:
-				q = client.Projects().WithUUID(identifier).Status().Any()
+				q = client.Projects().WithUUIDPrefix(identifier).Status().Any()
 			}
 
 			projects, err := q.All(cmd.Context())
@@ -44,6 +44,9 @@ func NewProjectCmd() *cobra.Command {
 				return err
 			}
 
+			if len(projects) == 0 {
+				return fmt.Errorf("no project matches %q", identifier)
+			}
 			if len(projects) == 1 {
 				todos, err := client.Todos().
 					InProject(projects[0].UUID).

--- a/cmd/things3/cmd/root.go
+++ b/cmd/things3/cmd/root.go
@@ -22,6 +22,7 @@ func NewRootCmd() *cobra.Command {
 
 It provides read-only access to your Things 3 database and allows you to
 query tasks, projects, areas, and tags from the command line.`,
+		SilenceUsage: true,
 	}
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
@@ -30,6 +31,7 @@ query tasks, projects, areas, and tags from the command line.`,
 	cmd.PersistentFlags().IntP(flagLimit, "n", 0, "max items to display (0 for unlimited)")
 	cmd.PersistentFlags().BoolP(flagJSON, "j", false, "output as JSON")
 	cmd.PersistentFlags().BoolP(flagYAML, "y", false, "output as YAML")
+	cmd.MarkFlagsMutuallyExclusive(flagJSON, flagYAML)
 
 	// Register subcommands
 	cmd.AddCommand(NewVersionCmd())

--- a/cmd/things3/cmd/todo.go
+++ b/cmd/things3/cmd/todo.go
@@ -44,6 +44,9 @@ func NewTodoCmd() *cobra.Command {
 				return err
 			}
 
+			if len(todos) == 0 {
+				return fmt.Errorf("no todo matches %q", identifier)
+			}
 			if len(todos) == 1 {
 				return outputTodoDetail(cmd, &todos[0])
 			}

--- a/errors.go
+++ b/errors.go
@@ -45,7 +45,8 @@ var (
 
 // URL Scheme Operation Errors - aliased from internal/scheme.
 var (
-	// ErrEmptyToken is returned when an empty token is provided to WithToken.
+	// ErrEmptyToken is returned when the auth token resolves to empty for an
+	// operation that requires one (update commands and batch updates).
 	ErrEmptyToken = scheme.ErrEmptyToken
 	// ErrIDRequired is returned when id is missing for an update operation.
 	ErrIDRequired = scheme.ErrIDRequired

--- a/interfaces.go
+++ b/interfaces.go
@@ -79,6 +79,10 @@ type DateFilter[T any] interface {
 // ============================================================================
 // Layer 3: Composed Query Builder Interfaces
 // ============================================================================
+//
+// Query builders are copy-on-write: every chainable method returns a new
+// builder and leaves the receiver unchanged, so a base builder can be forked
+// into independent queries.
 
 // TodoQueryBuilder provides a fluent interface for building todo queries.
 type TodoQueryBuilder interface {
@@ -119,6 +123,7 @@ type ProjectQueryBuilder interface {
 	ProjectQueryExecutor
 
 	WithUUID(uuid string) ProjectQueryBuilder
+	WithUUIDPrefix(prefix string) ProjectQueryBuilder
 	WithTitle(title string) ProjectQueryBuilder
 
 	Status() StatusFilter[ProjectQueryBuilder]
@@ -144,6 +149,7 @@ type HeadingQueryBuilder interface {
 	HeadingQueryExecutor
 
 	WithUUID(uuid string) HeadingQueryBuilder
+	WithUUIDPrefix(prefix string) HeadingQueryBuilder
 	InProject(uuid string) HeadingQueryBuilder
 	Limit(n int) HeadingQueryBuilder
 }

--- a/internal/database/date.go
+++ b/internal/database/date.go
@@ -81,9 +81,10 @@ func stringToThingsDate(isoDate string) (int64, error) {
 
 // thingsTimeToString converts a Things time integer to time string (HH:MM).
 // Things time format: hhhhhmmmmmm00000000000000000000 (31-bit binary)
-// Returns empty string if thingsTime is 0 or negative.
+// Zero encodes a valid 00:00 reminder ("no reminder" is NULL in the
+// database, never 0). Returns empty string only for negative values.
 func thingsTimeToString(thingsTime int64) string {
-	if thingsTime <= 0 {
+	if thingsTime < 0 {
 		return ""
 	}
 
@@ -125,10 +126,12 @@ func thingsDateExpressionToISODate(expr string) string {
 }
 
 // thingsTimeExpressionToISOTime creates a SQL expression to convert Things time to HH:MM format.
+// The NULL check must be explicit: a packed value of 0 is a valid 00:00
+// reminder, so truthiness (CASE WHEN expr) would wrongly drop midnight.
 func thingsTimeExpressionToISOTime(expr string) string {
 	hours := fmt.Sprintf("(%s & %d) >> 26", expr, hourMask)
 	minutes := fmt.Sprintf("(%s & %d) >> 20", expr, minuteMask)
 
 	isoTime := fmt.Sprintf("printf('%%02d:%%02d', %s, %s)", hours, minutes)
-	return fmt.Sprintf("CASE WHEN %s THEN %s ELSE %s END", expr, isoTime, expr)
+	return fmt.Sprintf("CASE WHEN %s IS NOT NULL THEN %s ELSE NULL END", expr, isoTime)
 }

--- a/internal/database/date_test.go
+++ b/internal/database/date_test.go
@@ -169,9 +169,9 @@ func Test_thingsTimeToString(t *testing.T) {
 			want:       "12:34",
 		},
 		{
-			name:       "00:00",
+			name:       "00:00 midnight is a valid reminder",
 			thingsTime: 0,
-			want:       "",
+			want:       "00:00",
 		},
 		{
 			name:       "negative",
@@ -369,12 +369,11 @@ func Test_ThingsTime_BoundaryValues(t *testing.T) {
 		thingsTime int64
 		expected   string
 	}{
-		// Zero and negative
-		{"zero", 0, ""},
+		// Negative is invalid
 		{"negative", -1, ""},
 
-		// Valid times
-		{"midnight", (0 << 26) | (0 << 20), ""}, // 00:00 returns empty (treated as no time)
+		// Valid times ("no reminder" is NULL in the database, never 0)
+		{"midnight", (0 << 26) | (0 << 20), "00:00"},
 		{"one minute past midnight", (0 << 26) | (1 << 20), "00:01"},
 		{"noon", (12 << 26) | (0 << 20), "12:00"},
 		{"max time", (23 << 26) | (59 << 20), "23:59"},

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -27,6 +27,27 @@ func escapeString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
+// likeEscapeChar is the escape character for LIKE patterns, declared once so
+// escaped patterns and their ESCAPE clauses stay in sync.
+const likeEscapeChar = `\`
+
+// escapeLikePattern escapes LIKE metacharacters (%, _) and the escape
+// character itself so user input matches literally inside a LIKE pattern.
+// The pattern must be used with an ESCAPE clause (see likeSQL).
+func escapeLikePattern(s string) string {
+	s = strings.ReplaceAll(s, likeEscapeChar, likeEscapeChar+likeEscapeChar)
+	s = strings.ReplaceAll(s, "%", likeEscapeChar+"%")
+	s = strings.ReplaceAll(s, "_", likeEscapeChar+"_")
+	return s
+}
+
+// likeSQL returns "column LIKE 'pattern' ESCAPE '\'" where value is matched
+// literally and prefix/suffix hold the intended wildcards ("%" or "").
+func likeSQL(column, prefix, value, suffix string) string {
+	escaped := escapeString(escapeLikePattern(value))
+	return fmt.Sprintf("%s LIKE '%s%s%s' ESCAPE '%s'", column, prefix, escaped, suffix, likeEscapeChar)
+}
+
 // joinConditions joins SQL conditions with AND, returns "TRUE" if empty.
 func joinConditions(conditions []string) string {
 	if len(conditions) == 0 {
@@ -76,7 +97,10 @@ func (w *whereBuilder) addFilter(column string, value *string, exists *bool) {
 	}
 }
 
-// addOrFilter adds an OR filter across two columns with value-or-existence fallback.
+// addOrFilter adds a filter across two columns with value-or-existence fallback.
+// A value or exists=true matches if either column matches (OR). For
+// exists=false, De Morgan requires both columns to be NULL (AND), otherwise
+// "has neither" would wrongly match rows where only one column is set.
 func (w *whereBuilder) addOrFilter(col1, col2 string, value *string, exists *bool) {
 	if value != nil {
 		escaped := escapeString(*value)
@@ -85,7 +109,11 @@ func (w *whereBuilder) addOrFilter(col1, col2 string, value *string, exists *boo
 			fmt.Sprintf("%s = '%s'", col2, escaped),
 		)
 	} else if exists != nil {
-		w.addOr(existsSQL(col1, *exists), existsSQL(col2, *exists))
+		if *exists {
+			w.addOr(existsSQL(col1, true), existsSQL(col2, true))
+		} else {
+			w.addRawf("(%s AND %s)", existsSQL(col1, false), existsSQL(col2, false))
+		}
 	}
 }
 
@@ -96,24 +124,35 @@ func (w *whereBuilder) addIntEqual(column string, value *int) {
 	}
 }
 
-// addLike adds a LIKE pattern condition.
-func (w *whereBuilder) addLike(column, pattern string) {
-	if pattern != "" {
-		w.addRawf("%s LIKE '%s'", column, escapeString(pattern))
+// addLikePrefix adds a prefix-match condition; LIKE metacharacters in value
+// match literally.
+func (w *whereBuilder) addLikePrefix(column, value string) {
+	if value != "" {
+		w.add(likeSQL(column, "", value, "%"))
 	}
 }
 
-// addTruthy adds a boolean column check with NULL handling.
-//   - true:  "column"
-//   - false: "NOT IFNULL(column, 0)"
-func (w *whereBuilder) addTruthy(column string, value *bool) {
+// addLikeContains adds a substring-match condition; LIKE metacharacters in
+// value match literally.
+func (w *whereBuilder) addLikeContains(column, value string) {
+	if value != "" {
+		w.add(likeSQL(column, "%", value, "%"))
+	}
+}
+
+// addTruthy adds a boolean column check, treating NULL as nullDefault.
+// Pass 0 when NULL means false (e.g. trashed) and 1 when NULL means true
+// (e.g. AREA.visible, which is NULL until the user hides the area).
+//   - true:  "IFNULL(column, nullDefault)"
+//   - false: "NOT IFNULL(column, nullDefault)"
+func (w *whereBuilder) addTruthy(column string, value *bool, nullDefault int) {
 	if value == nil {
 		return
 	}
 	if *value {
-		*w = append(*w, column)
+		w.addRawf("IFNULL(%s, %d)", column, nullDefault)
 	} else {
-		w.addRawf("NOT IFNULL(%s, 0)", column)
+		w.addRawf("NOT IFNULL(%s, %d)", column, nullDefault)
 	}
 }
 
@@ -131,25 +170,28 @@ func (w *whereBuilder) addOr(parts ...string) {
 }
 
 // addSearch adds a full-text search condition across multiple columns.
+// LIKE metacharacters in the query match literally.
 func (w *whereBuilder) addSearch(query string) {
 	if query == "" {
 		return
 	}
-	escaped := escapeString(query)
 	columns := []string{"TASK.title", "TASK.notes", "AREA.title"}
 	var searches []string
 	for _, col := range columns {
-		searches = append(searches, fmt.Sprintf("%s LIKE '%%%s%%'", col, escaped))
+		searches = append(searches, likeSQL(col, "%", query, "%"))
 	}
 	*w = append(*w, "("+strings.Join(searches, " OR ")+")")
 }
 
 // addCreatedAfter adds a time-based filter for creation date.
+// The instant is normalized to local time so the same instant yields
+// identical SQL regardless of the Location carried by t.
 func (w *whereBuilder) addCreatedAfter(column string, t time.Time) {
 	if t.IsZero() {
 		return
 	}
-	w.addRawf("datetime(%s, 'unixepoch', 'localtime') > '%s'", column, t.Format("2006-01-02 15:04:05"))
+	local := t.In(time.Local).Format("2006-01-02 15:04:05")
+	w.addRawf("datetime(%s, 'unixepoch', 'localtime') > '%s'", column, local)
 }
 
 // addDateFilter adds a date filter condition.
@@ -186,11 +228,12 @@ func (w *whereBuilder) addDateFilter(column string, v *DateFilterValue, isThings
 		return
 	}
 
-	// Specific date comparison
+	// Specific date comparison. Normalize the instant to local time so the
+	// same instant yields the same calendar date regardless of its Location.
 	if v.Date == nil {
 		return
 	}
-	dateVal, ok := formatDateValue(v.Date.Format(time.DateOnly), isThingsDate)
+	dateVal, ok := formatDateValue(v.Date.In(time.Local).Format(time.DateOnly), isThingsDate)
 	if !ok {
 		return
 	}

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -34,7 +34,7 @@ func TestWhereBuilder_addStringEqual(t *testing.T) {
 
 	var w3 whereBuilder
 	w3.addStringEqual("col", nil)
-	assert.Equal(t, "TRUE", w3.sql())
+	assert.Equal(t, sqlTrue, w3.sql())
 }
 
 func TestWhereBuilder_addIntEqual(t *testing.T) {
@@ -44,7 +44,7 @@ func TestWhereBuilder_addIntEqual(t *testing.T) {
 
 	var w2 whereBuilder
 	w2.addIntEqual("col", nil)
-	assert.Equal(t, "TRUE", w2.sql())
+	assert.Equal(t, sqlTrue, w2.sql())
 }
 
 func TestWhereBuilder_addExists(t *testing.T) {
@@ -79,7 +79,7 @@ func TestWhereBuilder_addFilter(t *testing.T) {
 	t.Run("both nil", func(t *testing.T) {
 		var w whereBuilder
 		w.addFilter("col", nil, nil)
-		assert.Equal(t, "TRUE", w.sql())
+		assert.Equal(t, sqlTrue, w.sql())
 	})
 }
 
@@ -96,43 +96,96 @@ func TestWhereBuilder_addOrFilter(t *testing.T) {
 		assert.Equal(t, "(a IS NOT NULL OR b IS NOT NULL)", w.sql())
 	})
 
-	t.Run("exists false", func(t *testing.T) {
+	t.Run("exists false requires both columns NULL", func(t *testing.T) {
 		var w whereBuilder
 		w.addOrFilter("a", "b", nil, new(false))
-		assert.Equal(t, "(a IS NULL OR b IS NULL)", w.sql())
+		assert.Equal(t, "(a IS NULL AND b IS NULL)", w.sql())
 	})
 
 	t.Run("both nil", func(t *testing.T) {
 		var w whereBuilder
 		w.addOrFilter("a", "b", nil, nil)
-		assert.Equal(t, "TRUE", w.sql())
+		assert.Equal(t, sqlTrue, w.sql())
 	})
 }
 
-func TestWhereBuilder_addLike(t *testing.T) {
-	var w whereBuilder
-	w.addLike("col", "ABC%")
-	assert.Equal(t, "col LIKE 'ABC%'", w.sql())
-
-	var w2 whereBuilder
-	w2.addLike("col", "")
-	assert.Equal(t, "TRUE", w2.sql())
-}
-
-func TestWhereBuilder_addTruthy(t *testing.T) {
+func TestWhereBuilder_addLikePrefix(t *testing.T) {
 	tests := []struct {
 		name  string
-		value *bool
+		value string
 		want  string
 	}{
-		{"nil", nil, "TRUE"},
-		{"true", new(true), "col"},
-		{"false", new(false), "NOT IFNULL(col, 0)"},
+		{"no metacharacters", "ABC", `col LIKE 'ABC%' ESCAPE '\'`},
+		{"empty skipped", "", sqlTrue},
+		{"percent escaped", "50%", `col LIKE '50\%%' ESCAPE '\'`},
+		{"underscore escaped", "a_b", `col LIKE 'a\_b%' ESCAPE '\'`},
+		{"backslash escaped", `a\b`, `col LIKE 'a\\b%' ESCAPE '\'`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var w whereBuilder
-			w.addTruthy("col", tt.value)
+			w.addLikePrefix("col", tt.value)
+			assert.Equal(t, tt.want, w.sql())
+		})
+	}
+}
+
+func TestWhereBuilder_addLikeContains(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"no metacharacters", "milk", `col LIKE '%milk%' ESCAPE '\'`},
+		{"empty skipped", "", sqlTrue},
+		{"percent escaped", "%", `col LIKE '%\%%' ESCAPE '\'`},
+		{"underscore escaped", "To_Do", `col LIKE '%To\_Do%' ESCAPE '\'`},
+		{"quote escaped", "it's", `col LIKE '%it''s%' ESCAPE '\'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w whereBuilder
+			w.addLikeContains("col", tt.value)
+			assert.Equal(t, tt.want, w.sql())
+		})
+	}
+}
+
+func Test_escapeLikePattern(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"abc", "abc"},
+		{"%", `\%`},
+		{"_", `\_`},
+		{`\`, `\\`},
+		{`100%_done\ok`, `100\%\_done\\ok`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, escapeLikePattern(tt.input))
+		})
+	}
+}
+
+func TestWhereBuilder_addTruthy(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       *bool
+		nullDefault int
+		want        string
+	}{
+		{"nil", nil, 0, sqlTrue},
+		{"true null default 0", new(true), 0, "IFNULL(col, 0)"},
+		{"false null default 0", new(false), 0, "NOT IFNULL(col, 0)"},
+		{"true null default 1", new(true), 1, "IFNULL(col, 1)"},
+		{"false null default 1", new(false), 1, "NOT IFNULL(col, 1)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w whereBuilder
+			w.addTruthy("col", tt.value, tt.nullDefault)
 			assert.Equal(t, tt.want, w.sql())
 		})
 	}
@@ -149,19 +202,27 @@ func TestWhereBuilder_addOr(t *testing.T) {
 
 	var w3 whereBuilder
 	w3.addOr("", "")
-	assert.Equal(t, "TRUE", w3.sql())
+	assert.Equal(t, sqlTrue, w3.sql())
 }
 
 func TestWhereBuilder_addSearch(t *testing.T) {
 	var w whereBuilder
 	w.addSearch("buy milk")
 	assert.Equal(t,
-		"(TASK.title LIKE '%buy milk%' OR TASK.notes LIKE '%buy milk%' OR AREA.title LIKE '%buy milk%')",
+		`(TASK.title LIKE '%buy milk%' ESCAPE '\' OR TASK.notes LIKE '%buy milk%' ESCAPE '\' OR AREA.title LIKE '%buy milk%' ESCAPE '\')`,
 		w.sql())
 
 	var w2 whereBuilder
 	w2.addSearch("")
-	assert.Equal(t, "TRUE", w2.sql())
+	assert.Equal(t, sqlTrue, w2.sql())
+}
+
+func TestWhereBuilder_addSearch_escapesLikeMetacharacters(t *testing.T) {
+	var w whereBuilder
+	w.addSearch("%")
+	assert.Equal(t,
+		`(TASK.title LIKE '%\%%' ESCAPE '\' OR TASK.notes LIKE '%\%%' ESCAPE '\' OR AREA.title LIKE '%\%%' ESCAPE '\')`,
+		w.sql())
 }
 
 func TestWhereBuilder_addCreatedAfter(t *testing.T) {
@@ -171,14 +232,28 @@ func TestWhereBuilder_addCreatedAfter(t *testing.T) {
 
 	var w2 whereBuilder
 	w2.addCreatedAfter("creationDate", time.Time{})
-	assert.Equal(t, "TRUE", w2.sql())
+	assert.Equal(t, sqlTrue, w2.sql())
+}
+
+// The same instant must yield identical SQL regardless of the Location
+// carried by the time.Time value.
+func TestWhereBuilder_addCreatedAfter_locationInsensitive(t *testing.T) {
+	instant := time.Date(2024, 6, 15, 10, 30, 0, 0, time.FixedZone("EAST", 14*3600))
+
+	var east, west, local whereBuilder
+	east.addCreatedAfter("creationDate", instant)
+	west.addCreatedAfter("creationDate", instant.In(time.FixedZone("WEST", -12*3600)))
+	local.addCreatedAfter("creationDate", instant.In(time.Local))
+
+	assert.Equal(t, local.sql(), east.sql())
+	assert.Equal(t, local.sql(), west.sql())
 }
 
 func TestWhereBuilder_addDateFilter(t *testing.T) {
 	t.Run("nil value", func(t *testing.T) {
 		var w whereBuilder
 		w.addDateFilter("col", nil, true)
-		assert.Equal(t, "TRUE", w.sql())
+		assert.Equal(t, sqlTrue, w.sql())
 	})
 
 	t.Run("exists true", func(t *testing.T) {
@@ -221,15 +296,28 @@ func TestWhereBuilder_addDateFilter(t *testing.T) {
 		var w whereBuilder
 		w.addDateFilter("stopDate", &DateFilterValue{
 			Operator: "=",
-			Date:     new(time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)),
+			Date:     new(time.Date(2024, 6, 15, 0, 0, 0, 0, time.Local)),
 		}, false)
 		assert.Equal(t, "date(stopDate, 'unixepoch', 'localtime') = date('2024-06-15')", w.sql())
+	})
+
+	t.Run("specific date is location insensitive", func(t *testing.T) {
+		instant := time.Date(2024, 6, 15, 12, 0, 0, 0, time.FixedZone("EAST", 14*3600))
+		for _, isThingsDate := range []bool{true, false} {
+			var east, west whereBuilder
+			east.addDateFilter("col", &DateFilterValue{Operator: "=", Date: new(instant)}, isThingsDate)
+			west.addDateFilter("col", &DateFilterValue{
+				Operator: "=",
+				Date:     new(instant.In(time.FixedZone("WEST", -12*3600))),
+			}, isThingsDate)
+			assert.Equal(t, east.sql(), west.sql(), "isThingsDate=%v", isThingsDate)
+		}
 	})
 }
 
 func TestWhereBuilder_empty(t *testing.T) {
 	var w whereBuilder
-	assert.Equal(t, "TRUE", w.sql())
+	assert.Equal(t, sqlTrue, w.sql())
 }
 
 func TestExistsSQL(t *testing.T) {

--- a/internal/database/integration_test.go
+++ b/internal/database/integration_test.go
@@ -1,0 +1,370 @@
+package database
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Well-known rows and counts from the fixture database.
+const (
+	fixtureTodoInProject = "E18tg5qepzrQk9J6jQtb5C" // creationDate epoch 1616958920
+	fixtureTodoInToday   = "5pUx6PESj3ctFYbgth1PXY" // startDate 2021-03-28, tag "Office"
+	fixtureTodoInHeading = "HbKGAeZKFDkWH5osSBNHvz" // deadline 2040-11-04
+	fixtureAreaWithTags  = "DciSFacytdrNG1nRaMJPgY" // tags "Errand" and "Important"
+
+	fixtureTodoInProjectCreationEpoch = int64(1616958920)
+	fixtureIncompleteTodos            = 15
+	fixtureAreas                      = 3
+)
+
+// Task type and status values used by fixture queries.
+const (
+	typeTodo         = 0
+	statusIncomplete = 0
+)
+
+// fixtureDatabasePath copies the shared fixture database into the test's
+// temporary directory so each test can open (and mutate) its own copy.
+func fixtureDatabasePath(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	src := filepath.Join(filepath.Dir(filename), "..", "..", "testdata", "main.sqlite")
+
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+
+	dst := filepath.Join(t.TempDir(), "main.sqlite")
+	require.NoError(t, os.WriteFile(dst, data, 0o600)) //nolint:gosec // dst is from t.TempDir(), not user input
+	return dst
+}
+
+// openFixtureDB opens a private copy of the fixture database.
+func openFixtureDB(t *testing.T) *DB {
+	t.Helper()
+	return openDBAt(t, fixtureDatabasePath(t))
+}
+
+// openDBAt opens the database at path and closes it when the test finishes.
+func openDBAt(t *testing.T, path string) *DB {
+	t.Helper()
+	d, err := Open(WithPath(path))
+	require.NoError(t, err)
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// mutateFixture executes write statements against a fixture database copy.
+func mutateFixture(t *testing.T, path string, statements ...string) {
+	t.Helper()
+	raw, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	defer raw.Close()
+
+	for _, stmt := range statements {
+		_, err := raw.ExecContext(t.Context(), stmt)
+		require.NoError(t, err)
+	}
+}
+
+// queryTaskByUUID fetches a single task row by UUID.
+func queryTaskByUUID(t *testing.T, d *DB, uuid string) TaskRow {
+	t.Helper()
+	rows, err := d.QueryTasks(t.Context(), &TaskFilter{UUID: &uuid})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	return rows[0]
+}
+
+// taskUUIDs extracts UUIDs from task rows.
+func taskUUIDs(rows []TaskRow) []string {
+	uuids := make([]string, len(rows))
+	for i := range rows {
+		uuids[i] = rows[i].UUID
+	}
+	return uuids
+}
+
+// =============================================================================
+// Timezone Model (instants come from raw epochs, packed dates are local days)
+// =============================================================================
+
+func TestIntegration_CreatedAtMatchesRawEpoch(t *testing.T) {
+	d := openFixtureDB(t)
+
+	row := queryTaskByUUID(t, d, fixtureTodoInProject)
+
+	assert.Equal(t, fixtureTodoInProjectCreationEpoch, row.Created.Unix(),
+		"Created must be the raw database epoch regardless of machine timezone")
+	assert.Equal(t, time.Local, row.Created.Location())
+	assert.False(t, row.Modified.IsZero())
+}
+
+func TestIntegration_PackedDatesParseAsLocalMidnight(t *testing.T) {
+	d := openFixtureDB(t)
+
+	todayTask := queryTaskByUUID(t, d, fixtureTodoInToday)
+	require.NotNil(t, todayTask.StartDate)
+	assert.True(t, todayTask.StartDate.Equal(time.Date(2021, 3, 28, 0, 0, 0, 0, time.Local)),
+		"StartDate %v must equal local midnight 2021-03-28", todayTask.StartDate)
+
+	headingTask := queryTaskByUUID(t, d, fixtureTodoInHeading)
+	require.NotNil(t, headingTask.Deadline)
+	assert.True(t, headingTask.Deadline.Equal(time.Date(2040, 11, 4, 0, 0, 0, 0, time.Local)),
+		"Deadline %v must equal local midnight 2040-11-04", headingTask.Deadline)
+}
+
+func TestIntegration_StopDateMatchesLocaltimeCalendarDay(t *testing.T) {
+	d := openFixtureDB(t)
+	ctx := t.Context()
+
+	// Ground truth straight from SQLite: raw epoch and localtime calendar day.
+	type stopInfo struct {
+		epoch int64
+		day   string
+	}
+	expected := make(map[string]stopInfo)
+	rawRows, err := d.ExecuteQuery(ctx,
+		"SELECT uuid, CAST(stopDate AS INTEGER), date(stopDate, 'unixepoch', 'localtime') FROM TMTask WHERE stopDate IS NOT NULL")
+	require.NoError(t, err)
+	defer rawRows.Close()
+	for rawRows.Next() {
+		var uuid, day string
+		var epoch int64
+		require.NoError(t, rawRows.Scan(&uuid, &epoch, &day))
+		expected[uuid] = stopInfo{epoch: epoch, day: day}
+	}
+	require.NoError(t, rawRows.Err())
+
+	taskType := typeTodo
+	rows, err := d.QueryTasks(ctx, &TaskFilter{
+		TaskType:       &taskType,
+		StopDateFilter: &DateFilterValue{HasDate: new(true)},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+
+	for _, row := range rows {
+		require.NotNil(t, row.StopDate, "todo %s should have a stop date", row.UUID)
+		want, ok := expected[row.UUID]
+		require.True(t, ok, "todo %s missing from raw stopDate map", row.UUID)
+		assert.Equal(t, want.epoch, row.StopDate.Unix(),
+			"todo %s StopDate instant must match the raw epoch", row.UUID)
+		assert.Equal(t, want.day, row.StopDate.In(time.Local).Format(time.DateOnly),
+			"todo %s StopDate calendar day must match SQLite localtime day", row.UUID)
+	}
+}
+
+// =============================================================================
+// CreatedAfter Location Insensitivity
+// =============================================================================
+
+func TestIntegration_CreatedAfterLocationInsensitive(t *testing.T) {
+	d := openFixtureDB(t)
+	ctx := t.Context()
+
+	taskType := typeTodo
+	pivot := time.Date(2021, 3, 29, 6, 0, 0, 0, time.Local)
+
+	local, err := d.QueryTasks(ctx, &TaskFilter{TaskType: &taskType, CreatedAfter: &pivot})
+	require.NoError(t, err)
+
+	pivotUTC := pivot.UTC()
+	utc, err := d.QueryTasks(ctx, &TaskFilter{TaskType: &taskType, CreatedAfter: &pivotUTC})
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, taskUUIDs(local), taskUUIDs(utc),
+		"the same instant in different Locations must select the same rows")
+	assert.NotEmpty(t, local)
+	for _, row := range local {
+		assert.True(t, row.Created.After(pivot),
+			"todo %s Created %v must be after pivot %v", row.UUID, row.Created, pivot)
+	}
+}
+
+// =============================================================================
+// HasProject Partition
+// =============================================================================
+
+func TestIntegration_HasProjectPartition(t *testing.T) {
+	d := openFixtureDB(t)
+	ctx := t.Context()
+
+	incompleteTodos := func(hasProject *bool) []TaskRow {
+		taskType, status := typeTodo, statusIncomplete
+		rows, err := d.QueryTasks(ctx, &TaskFilter{
+			TaskType:   &taskType,
+			Status:     &status,
+			HasProject: hasProject,
+		})
+		require.NoError(t, err)
+		return rows
+	}
+
+	all := incompleteTodos(nil)
+	withProject := incompleteTodos(new(true))
+	withoutProject := incompleteTodos(new(false))
+
+	require.Len(t, all, fixtureIncompleteTodos)
+	assert.Len(t, withProject, len(all)-len(withoutProject), "sets must be disjoint")
+	assert.ElementsMatch(t, taskUUIDs(all),
+		append(taskUUIDs(withProject), taskUUIDs(withoutProject)...),
+		"HasProject(true) and HasProject(false) must partition all incomplete todos")
+
+	for _, row := range withoutProject {
+		assert.Nil(t, row.ProjectUUID,
+			"HasProject(false) returned todo %s with project", row.UUID)
+		assert.Nil(t, row.HeadingUUID,
+			"HasProject(false) returned todo %s inside a heading", row.UUID)
+	}
+	for _, row := range withProject {
+		assert.True(t, row.ProjectUUID != nil || row.HeadingUUID != nil,
+			"HasProject(true) returned todo %s without project context", row.UUID)
+	}
+}
+
+// =============================================================================
+// LIKE Metacharacter Escaping
+// =============================================================================
+
+func TestIntegration_SearchTreatsWildcardsLiterally(t *testing.T) {
+	d := openFixtureDB(t)
+	ctx := t.Context()
+	taskType := typeTodo
+
+	literalPercent, err := d.QueryTasks(ctx, &TaskFilter{
+		TaskType:    &taskType,
+		SearchQuery: new("%"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, literalPercent,
+		"search for literal %% must only match rows containing a percent sign")
+
+	sanity, err := d.QueryTasks(ctx, &TaskFilter{
+		TaskType:    &taskType,
+		SearchQuery: new("To-Do"),
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, sanity, "plain text search must still match")
+}
+
+func TestIntegration_TitleFilterTreatsUnderscoreLiterally(t *testing.T) {
+	d := openFixtureDB(t)
+	ctx := t.Context()
+	taskType := typeTodo
+
+	underscore, err := d.QueryTasks(ctx, &TaskFilter{
+		TaskType: &taskType,
+		Title:    new("To_Do"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, underscore,
+		"underscore in a title filter must not act as a single-character wildcard")
+
+	sanity, err := d.QueryTasks(ctx, &TaskFilter{
+		TaskType: &taskType,
+		Title:    new("To-Do"),
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, sanity, "plain title filter must still match")
+}
+
+// =============================================================================
+// Area Visibility NULL Handling
+// =============================================================================
+
+func TestIntegration_AreaVisibleTreatsNullAsVisible(t *testing.T) {
+	d := openFixtureDB(t)
+	ctx := t.Context()
+
+	visible, err := d.QueryAreas(ctx, AreaFilter{Visible: new(true)})
+	require.NoError(t, err)
+	assert.Len(t, visible, fixtureAreas,
+		"areas with NULL visible were never hidden and must count as visible")
+
+	hidden, err := d.QueryAreas(ctx, AreaFilter{Visible: new(false)})
+	require.NoError(t, err)
+	assert.Empty(t, hidden, "no fixture area has been explicitly hidden")
+}
+
+// =============================================================================
+// Midnight Reminder Round-Trip
+// =============================================================================
+
+func TestIntegration_MidnightReminderRoundTrip(t *testing.T) {
+	path := fixtureDatabasePath(t)
+	mutateFixture(t, path,
+		"UPDATE TMTask SET reminderTime = 0 WHERE uuid = '"+fixtureTodoInToday+"'")
+	d := openDBAt(t, path)
+
+	row := queryTaskByUUID(t, d, fixtureTodoInToday)
+
+	require.NotNil(t, row.ReminderTime, "a 00:00 reminder must not be dropped")
+	assert.Equal(t, "00:00", row.ReminderTime.Format(timeFormat))
+}
+
+func Test_thingsTimeExpressionToISOTime_SQL(t *testing.T) {
+	raw, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer raw.Close()
+
+	tests := []struct {
+		name    string
+		literal string
+		want    *string
+	}{
+		{"null means no reminder", "NULL", nil},
+		{"zero is midnight", "0", new("00:00")},
+		{"packed afternoon time", "840957952", new("12:34")},
+		{"packed end of day", "1605369856", new("23:59")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got sql.NullString
+			query := "SELECT " + thingsTimeExpressionToISOTime(tt.literal)
+			require.NoError(t, raw.QueryRowContext(t.Context(), query).Scan(&got))
+			if tt.want == nil {
+				assert.False(t, got.Valid, "expected NULL")
+			} else {
+				require.True(t, got.Valid)
+				assert.Equal(t, *tt.want, got.String)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Dangling Tag References
+// =============================================================================
+
+func TestIntegration_TagsOfTaskSkipsDanglingTagRef(t *testing.T) {
+	path := fixtureDatabasePath(t)
+	mutateFixture(t, path,
+		"INSERT INTO TMTaskTag (tasks, tags) VALUES ('"+fixtureTodoInToday+"', 'DanglingTagRef00000001')")
+	d := openDBAt(t, path)
+
+	tags, err := d.TagsOfTask(t.Context(), fixtureTodoInToday)
+
+	require.NoError(t, err, "a dangling tag reference must not fail the query")
+	assert.Equal(t, []string{"Office"}, tags)
+}
+
+func TestIntegration_TagsOfAreaSkipsDanglingTagRef(t *testing.T) {
+	path := fixtureDatabasePath(t)
+	mutateFixture(t, path,
+		"INSERT INTO TMAreaTag (areas, tags) VALUES ('"+fixtureAreaWithTags+"', 'DanglingTagRef00000002')")
+	d := openDBAt(t, path)
+
+	tags, err := d.TagsOfArea(t.Context(), fixtureAreaWithTags)
+
+	require.NoError(t, err, "a dangling tag reference must not fail the query")
+	assert.ElementsMatch(t, []string{"Errand", "Important"}, tags)
+}

--- a/internal/database/query.go
+++ b/internal/database/query.go
@@ -50,8 +50,8 @@ func (f *TaskFilter) buildWhere() string {
 	} else {
 		w.add("TASK." + filterIsNotTrashed)
 		notTrashed := false
-		w.addTruthy("PROJECT.trashed", &notTrashed)
-		w.addTruthy("PROJECT_OF_HEADING.trashed", &notTrashed)
+		w.addTruthy("PROJECT.trashed", &notTrashed, 0)
+		w.addTruthy("PROJECT_OF_HEADING.trashed", &notTrashed, 0)
 	}
 
 	// Integer field filters
@@ -62,10 +62,10 @@ func (f *TaskFilter) buildWhere() string {
 	// Identity filters
 	w.addStringEqual("TASK.uuid", f.UUID)
 	if f.UUIDPrefix != nil {
-		w.addLike("TASK.uuid", *f.UUIDPrefix+"%")
+		w.addLikePrefix("TASK.uuid", *f.UUIDPrefix)
 	}
 	if f.Title != nil {
-		w.addLike("TASK.title", "%"+*f.Title+"%")
+		w.addLikeContains("TASK.title", *f.Title)
 	}
 
 	// Relation filters
@@ -119,7 +119,8 @@ func (f *AreaFilter) buildWhere() string {
 
 	w.addStringEqual("AREA.uuid", f.UUID)
 	w.addStringEqual("AREA.title", f.Title)
-	w.addTruthy("AREA.visible", f.Visible)
+	// NULL visible means the user never hid the area, so NULL defaults to 1.
+	w.addTruthy("AREA.visible", f.Visible, 1)
 	w.addFilter("TAG.title", f.TagTitle, f.HasTag)
 
 	return w.sql()
@@ -246,16 +247,7 @@ func (d *DB) TagsOfTask(ctx context.Context, taskUUID string) ([]string, error) 
 	}
 	defer rows.Close()
 
-	var tags []string
-	for rows.Next() {
-		var title string
-		if err := rows.Scan(&title); err != nil {
-			return nil, err
-		}
-		tags = append(tags, title)
-	}
-
-	return tags, rows.Err()
+	return collectTagTitles(rows)
 }
 
 // TagsOfArea returns the tag titles for an area.
@@ -267,13 +259,22 @@ func (d *DB) TagsOfArea(ctx context.Context, areaUUID string) ([]string, error) 
 	}
 	defer rows.Close()
 
+	return collectTagTitles(rows)
+}
+
+// collectTagTitles scans tag titles from a LEFT-JOIN result, skipping NULL
+// titles produced by dangling tag references.
+func collectTagTitles(rows *sql.Rows) ([]string, error) {
 	var tags []string
 	for rows.Next() {
-		var title string
+		var title sql.NullString
 		if err := rows.Scan(&title); err != nil {
 			return nil, err
 		}
-		tags = append(tags, title)
+		if !title.Valid {
+			continue
+		}
+		tags = append(tags, title.String)
 	}
 
 	return tags, rows.Err()

--- a/internal/database/query_test.go
+++ b/internal/database/query_test.go
@@ -61,7 +61,22 @@ func TestTaskFilter_buildWhere(t *testing.T) {
 		{
 			name:   "uuid prefix",
 			filter: TaskFilter{UUIDPrefix: new("ABC")},
-			want:   defaultPrefix + and + "TASK.uuid LIKE 'ABC%'",
+			want:   defaultPrefix + and + `TASK.uuid LIKE 'ABC%' ESCAPE '\'`,
+		},
+		{
+			name:   "uuid prefix escapes wildcards",
+			filter: TaskFilter{UUIDPrefix: new("AB_C")},
+			want:   defaultPrefix + and + `TASK.uuid LIKE 'AB\_C%' ESCAPE '\'`,
+		},
+		{
+			name:   "title contains",
+			filter: TaskFilter{Title: new("milk")},
+			want:   defaultPrefix + and + `TASK.title LIKE '%milk%' ESCAPE '\'`,
+		},
+		{
+			name:   "title escapes wildcards",
+			filter: TaskFilter{Title: new("To_Do")},
+			want:   defaultPrefix + and + `TASK.title LIKE '%To\_Do%' ESCAPE '\'`,
 		},
 		{
 			name:   "area uuid",
@@ -94,9 +109,9 @@ func TestTaskFilter_buildWhere(t *testing.T) {
 			want:   defaultPrefix + and + "(TASK.project IS NOT NULL OR PROJECT_OF_HEADING.uuid IS NOT NULL)",
 		},
 		{
-			name:   "has project false",
+			name:   "has project false requires both columns NULL",
 			filter: TaskFilter{HasProject: new(false)},
-			want:   defaultPrefix + and + "(TASK.project IS NULL OR PROJECT_OF_HEADING.uuid IS NULL)",
+			want:   defaultPrefix + and + "(TASK.project IS NULL AND PROJECT_OF_HEADING.uuid IS NULL)",
 		},
 		{
 			name:   "heading uuid",
@@ -152,7 +167,7 @@ func TestTaskFilter_buildWhere(t *testing.T) {
 			name: "start date specific comparison",
 			filter: TaskFilter{StartDateFilter: &DateFilterValue{
 				Operator: ">=",
-				Date:     new(time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)),
+				Date:     new(time.Date(2024, 6, 15, 0, 0, 0, 0, time.Local)),
 			}},
 			want: defaultPrefix + and + "TASK.startDate >= 132671360",
 		},
@@ -170,7 +185,7 @@ func TestTaskFilter_buildWhere(t *testing.T) {
 			name: "stop date specific comparison (unix time)",
 			filter: TaskFilter{StopDateFilter: &DateFilterValue{
 				Operator: "=",
-				Date:     new(time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)),
+				Date:     new(time.Date(2024, 6, 15, 0, 0, 0, 0, time.Local)),
 			}},
 			want: defaultPrefix + and + "date(TASK.stopDate, 'unixepoch', 'localtime') = date('2024-06-15')",
 		},
@@ -187,12 +202,20 @@ func TestTaskFilter_buildWhere(t *testing.T) {
 		{
 			name:   "search query",
 			filter: TaskFilter{SearchQuery: new("buy milk")},
-			want:   defaultPrefix + and + "(TASK.title LIKE '%buy milk%' OR TASK.notes LIKE '%buy milk%' OR AREA.title LIKE '%buy milk%')",
+			want: defaultPrefix + and +
+				`(TASK.title LIKE '%buy milk%' ESCAPE '\' OR TASK.notes LIKE '%buy milk%' ESCAPE '\' OR AREA.title LIKE '%buy milk%' ESCAPE '\')`,
 		},
 		{
 			name:   "search with special chars",
 			filter: TaskFilter{SearchQuery: new("it's")},
-			want:   defaultPrefix + and + "(TASK.title LIKE '%it''s%' OR TASK.notes LIKE '%it''s%' OR AREA.title LIKE '%it''s%')",
+			want: defaultPrefix + and +
+				`(TASK.title LIKE '%it''s%' ESCAPE '\' OR TASK.notes LIKE '%it''s%' ESCAPE '\' OR AREA.title LIKE '%it''s%' ESCAPE '\')`,
+		},
+		{
+			name:   "search escapes like wildcards",
+			filter: TaskFilter{SearchQuery: new("%")},
+			want: defaultPrefix + and +
+				`(TASK.title LIKE '%\%%' ESCAPE '\' OR TASK.notes LIKE '%\%%' ESCAPE '\' OR AREA.title LIKE '%\%%' ESCAPE '\')`,
 		},
 		{
 			name: "complex filter combination",
@@ -261,14 +284,14 @@ func TestAreaFilter_buildWhere(t *testing.T) {
 			want:   "AREA.title = 'Work'",
 		},
 		{
-			name:   "visible true",
+			name:   "visible true treats NULL as visible",
 			filter: AreaFilter{Visible: new(true)},
-			want:   "AREA.visible",
+			want:   "IFNULL(AREA.visible, 1)",
 		},
 		{
-			name:   "visible false",
+			name:   "visible false treats NULL as visible",
 			filter: AreaFilter{Visible: new(false)},
-			want:   "NOT IFNULL(AREA.visible, 0)",
+			want:   "NOT IFNULL(AREA.visible, 1)",
 		},
 		{
 			name:   "tag title",
@@ -293,7 +316,7 @@ func TestAreaFilter_buildWhere(t *testing.T) {
 		{
 			name:   "multiple filters",
 			filter: AreaFilter{UUID: new("area-1"), Visible: new(true)},
-			want:   "AREA.uuid = 'area-1'" + and + "AREA.visible",
+			want:   "AREA.uuid = 'area-1'" + and + "IFNULL(AREA.visible, 1)",
 		},
 	}
 

--- a/internal/database/scan.go
+++ b/internal/database/scan.go
@@ -7,9 +7,8 @@ import (
 
 // Time format constants used by Things 3 database.
 const (
-	dateFormat     = "2006-01-02"
-	dateTimeFormat = "2006-01-02 15:04:05"
-	timeFormat     = "15:04"
+	dateFormat = "2006-01-02"
+	timeFormat = "15:04"
 )
 
 // scanTaskRow scans a sql.Rows into a TaskRow.
@@ -36,8 +35,8 @@ type taskScanRow struct {
 	trashed, tags, checklist                       sql.NullInt64
 	areaUUID, areaTitle, projectUUID, projectTitle sql.NullString
 	headingUUID, headingTitle, notes, start        sql.NullString
-	startDate, deadline, reminderTime, stopDate    sql.NullString
-	created, modified                              sql.NullString
+	startDate, deadline, reminderTime              sql.NullString
+	stopDate, created, modified                    sql.NullFloat64
 }
 
 // toTaskRow converts raw scan values into a TaskRow.
@@ -61,9 +60,9 @@ func (s *taskScanRow) toTaskRow() *TaskRow {
 		StartDate:    parseDate(s.startDate),
 		Deadline:     parseDate(s.deadline),
 		ReminderTime: parseTime(s.reminderTime),
-		StopDate:     parseDateTime(s.stopDate),
-		Created:      parseDateTimeValue(s.created),
-		Modified:     parseDateTimeValue(s.modified),
+		StopDate:     unixTimePtr(s.stopDate),
+		Created:      unixTimeValue(s.created),
+		Modified:     unixTimeValue(s.modified),
 		Index:        s.index,
 		TodayIndex:   s.todayIndex,
 	}
@@ -105,7 +104,7 @@ func scanTagRow(rows *sql.Rows) (*TagRow, error) {
 func scanChecklistItemRow(rows *sql.Rows) (*ChecklistItemRow, error) {
 	var row ChecklistItemRow
 	var typeStr, stopDate sql.NullString
-	var created, modified sql.NullString
+	var created, modified sql.NullFloat64
 
 	err := rows.Scan(&row.Title, &row.Status, &stopDate, &typeStr, &row.UUID, &created, &modified)
 	if err != nil {
@@ -113,32 +112,20 @@ func scanChecklistItemRow(rows *sql.Rows) (*ChecklistItemRow, error) {
 	}
 
 	row.StopDate = parseDate(stopDate)
-	row.Created = parseDateTimeValue(created)
-	row.Modified = parseDateTimeValue(modified)
+	row.Created = unixTimeValue(created)
+	row.Modified = unixTimeValue(modified)
 
 	return &row, nil
 }
 
-// parseDate parses a date string in "2006-01-02" format.
-// Returns nil if the string is empty or invalid.
+// parseDate parses a date string in "2006-01-02" format as local midnight.
+// Things packed dates are calendar dates without a timezone, so they map to
+// the local day boundary. Returns nil if the string is empty or invalid.
 func parseDate(s sql.NullString) *time.Time {
 	if !s.Valid || s.String == "" {
 		return nil
 	}
-	t, err := time.Parse(dateFormat, s.String)
-	if err != nil {
-		return nil
-	}
-	return &t
-}
-
-// parseDateTime parses a datetime string in "2006-01-02 15:04:05" format.
-// Returns nil if the string is empty or invalid.
-func parseDateTime(s sql.NullString) *time.Time {
-	if !s.Valid || s.String == "" {
-		return nil
-	}
-	t, err := time.Parse(dateTimeFormat, s.String)
+	t, err := time.ParseInLocation(dateFormat, s.String, time.Local)
 	if err != nil {
 		return nil
 	}
@@ -146,7 +133,9 @@ func parseDateTime(s sql.NullString) *time.Time {
 }
 
 // parseTime parses a time string in "15:04" format.
-// Returns nil if the string is empty or invalid.
+// The result carries only a wall-clock time of day (date component is the
+// parse zero date); it does not represent an instant, so no location
+// normalization is needed. Returns nil if the string is empty or invalid.
 func parseTime(s sql.NullString) *time.Time {
 	if !s.Valid || s.String == "" {
 		return nil
@@ -163,12 +152,26 @@ func nullBool(n sql.NullInt64) bool {
 	return n.Valid && n.Int64 == 1
 }
 
-// parseDateTimeValue parses a datetime string, returning zero time on failure.
-func parseDateTimeValue(s sql.NullString) time.Time {
-	if t := parseDateTime(s); t != nil {
-		return *t
+// unixTimePtr converts a nullable Unix epoch value to a local-time instant.
+// Returns nil for NULL or zero epochs (Things stores "no timestamp" as NULL).
+func unixTimePtr(f sql.NullFloat64) *time.Time {
+	if !f.Valid {
+		return nil
 	}
-	return time.Time{}
+	t := unixToTime(f.Float64)
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+// unixTimeValue converts a nullable Unix epoch value to a local-time instant,
+// returning the zero time for NULL.
+func unixTimeValue(f sql.NullFloat64) time.Time {
+	if !f.Valid {
+		return time.Time{}
+	}
+	return unixToTime(f.Float64)
 }
 
 // nullString returns nil if NULL, otherwise returns pointer to string.

--- a/internal/database/sql.go
+++ b/internal/database/sql.go
@@ -68,9 +68,9 @@ func buildTasksSQL(wherePredicate, orderPredicate string, limit *int) string {
 			%s AS start_date,
 			%s AS deadline,
 			%s AS reminder_time,
-			datetime(TASK.%s, "unixepoch", "localtime") AS stop_date,
-			datetime(TASK.%s, "unixepoch", "localtime") AS created,
-			datetime(TASK.%s, "unixepoch", "localtime") AS modified,
+			TASK.%s AS stop_date,
+			TASK.%s AS created,
+			TASK.%s AS modified,
 			TASK.'index',
 			TASK.todayIndex AS today_index
 		FROM
@@ -168,8 +168,8 @@ func buildChecklistItemsSQL() string {
 			date(CHECKLIST_ITEM.stopDate, "unixepoch", "localtime") AS stop_date,
 			'checklist-item' as type,
 			CHECKLIST_ITEM.uuid,
-			datetime(CHECKLIST_ITEM.%s, "unixepoch", "localtime") AS created,
-			datetime(CHECKLIST_ITEM.%s, "unixepoch", "localtime") AS modified
+			CHECKLIST_ITEM.%s AS created,
+			CHECKLIST_ITEM.%s AS modified
 		FROM
 			%s AS CHECKLIST_ITEM
 		WHERE

--- a/internal/scheme/attrs.go
+++ b/internal/scheme/attrs.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // AttrStore abstracts attribute storage for URL params vs JSON attributes.
@@ -43,7 +44,7 @@ type ReminderStore interface {
 // StrParam defines metadata for string URL parameters including validation rules.
 type StrParam struct {
 	Key    string // URL parameter key (e.g., "title", "notes")
-	MaxLen int    // Maximum length (0 = no limit)
+	MaxLen int    // Maximum length in characters/runes (0 = no limit)
 	Err    error  // Error to return if validation fails
 }
 
@@ -57,7 +58,8 @@ type StrsParam struct {
 	Key      string // URL parameter key
 	Sep      string // Separator for joining values (e.g., "," for tags, "\n" for checklist)
 	MaxCount int    // Maximum item count (0 = no limit)
-	Err      error  // Error to return if validation fails
+	Err      error  // Error to return if count validation fails
+	SepErr   error  // Error to return when a value contains the separator
 }
 
 // TimeParam defines metadata for time URL parameters.
@@ -94,11 +96,16 @@ var (
 	ShowQuickEntryParam = BoolParam{Key: KeyShowQuickEntry}
 
 	// String slice parameters
-	TagsParam             = StrsParam{Key: KeyTags, Sep: ","}
-	AddTagsParam          = StrsParam{Key: KeyAddTags, Sep: ","}
-	ChecklistItemsParam   = StrsParam{Key: KeyChecklistItems, Sep: "\n", MaxCount: MaxChecklistItems, Err: ErrTooManyChecklistItems}
-	PrependChecklistParam = StrsParam{Key: KeyPrependChecklistItems, Sep: "\n"}
-	AppendChecklistParam  = StrsParam{Key: KeyAppendChecklistItems, Sep: "\n"}
+	TagsParam           = StrsParam{Key: KeyTags, Sep: ",", SepErr: ErrTagContainsComma}
+	AddTagsParam        = StrsParam{Key: KeyAddTags, Sep: ",", SepErr: ErrTagContainsComma}
+	ChecklistItemsParam = StrsParam{
+		Key: KeyChecklistItems, Sep: "\n",
+		MaxCount: MaxChecklistItems, Err: ErrTooManyChecklistItems,
+		SepErr: ErrChecklistItemContainsNewline,
+	}
+	PrependChecklistParam = StrsParam{Key: KeyPrependChecklistItems, Sep: "\n", SepErr: ErrChecklistItemContainsNewline}
+	AppendChecklistParam  = StrsParam{Key: KeyAppendChecklistItems, Sep: "\n", SepErr: ErrChecklistItemContainsNewline}
+	TodosParam            = StrsParam{Key: KeyTodos, Sep: "\n", SepErr: ErrTitleContainsNewline}
 
 	// Time parameters
 	CreationDateParam   = TimeParam{Key: KeyCreationDate}
@@ -116,13 +123,21 @@ var (
 	ErrNotesTooLong = fmt.Errorf("things3: notes exceed %d character limit", MaxNotesLength)
 	// ErrTooManyChecklistItems is returned when checklist exceeds the item limit.
 	ErrTooManyChecklistItems = fmt.Errorf("things3: checklist exceeds %d item limit", MaxChecklistItems)
+	// ErrTagContainsComma is returned when a tag contains a comma, the tag list separator.
+	ErrTagContainsComma = errors.New("things3: tag must not contain a comma")
+	// ErrChecklistItemContainsNewline is returned when a checklist item contains a newline, the item separator.
+	ErrChecklistItemContainsNewline = errors.New("things3: checklist item must not contain a newline")
+	// ErrTitleContainsNewline is returned when a title contains a newline, the title list separator.
+	ErrTitleContainsNewline = errors.New("things3: title must not contain a newline")
 )
 
 // Generic setter functions with type-safe parameter definitions.
 
 // SetStr sets a string attribute with optional length validation.
+// Length limits are counted in Unicode characters, matching the limits
+// documented by the Things URL scheme.
 func SetStr[T AttrBuilder](b T, p StrParam, value string) T {
-	if p.MaxLen > 0 && len(value) > p.MaxLen {
+	if p.MaxLen > 0 && utf8.RuneCountInString(value) > p.MaxLen {
 		b.SetErr(p.Err)
 		return b
 	}
@@ -137,10 +152,20 @@ func SetBool[T AttrBuilder](b T, p BoolParam, value bool) T {
 }
 
 // SetStrs sets a string slice attribute with optional count validation.
+// Values containing the separator are rejected because they would silently
+// split into multiple items when joined for the URL scheme.
 func SetStrs[T AttrBuilder](b T, p StrsParam, values []string) T {
 	if p.MaxCount > 0 && len(values) > p.MaxCount {
 		b.SetErr(p.Err)
 		return b
+	}
+	if p.Sep != "" {
+		for _, v := range values {
+			if strings.Contains(v, p.Sep) {
+				b.SetErr(p.SepErr)
+				return b
+			}
+		}
 	}
 	b.GetStore().SetStrings(p.Key, values, p.Sep)
 	return b
@@ -188,6 +213,11 @@ func SetDeadlineTime[T AttrBuilder](b T, t time.Time) T {
 
 // ErrInvalidReminderTime is returned when reminder hour or minute is out of range.
 var ErrInvalidReminderTime = errors.New("things3: invalid reminder time (hour must be 0-23, minute must be 0-59)")
+
+// ErrReminderNeedsDate is returned when a reminder is combined with a "when"
+// value that has no concrete date. Things accepts reminder times only with a
+// date, today, tomorrow, or evening; someday and anytime cannot carry one.
+var ErrReminderNeedsDate = errors.New("things3: reminder requires a concrete date, today, tomorrow, or evening (not someday or anytime)")
 
 // SetReminder sets the reminder time for builders that support it.
 func SetReminder[T AttrBuilder](b T, hour, minute int) T {
@@ -248,21 +278,31 @@ func (u *URLAttrs) SetReminder(hour, minute int) {
 	u.ReminderMin = &minute
 }
 
-// FinalizeWhen returns the final "when" parameter value with reminder time appended.
-// If reminder is set but no "when" value exists, defaults to "today".
-// Format: "when@HH:MM" (e.g., "today@15:30", "2024-03-15@14:00")
-func (u *URLAttrs) FinalizeWhen() {
-	if u.ReminderHour == nil {
-		return
+// QueryValues returns the URL query values for the stored parameters.
+// When a reminder is set, its time is appended to the "when" value in
+// "when@HH:MM" format (e.g., "today@15:30", "2024-03-15@14:00"),
+// defaulting to "today" when no "when" value exists.
+// The receiver is never mutated, so repeated calls yield identical results.
+func (u *URLAttrs) QueryValues() (url.Values, error) {
+	query := url.Values{}
+	for k, v := range u.Params {
+		query.Set(k, v)
 	}
 
-	w, exists := u.Params[KeyWhen]
-	if !exists || w == "" {
+	if u.ReminderHour == nil {
+		return query, nil
+	}
+
+	w := u.Params[KeyWhen]
+	if w == "" {
 		w = "today" // default to today if no when specified
 	}
+	if w == string(WhenSomeday) || w == string(WhenAnytime) {
+		return nil, ErrReminderNeedsDate
+	}
 
-	// Append reminder time in HH:MM format
-	u.Params[KeyWhen] = fmt.Sprintf("%s@%02d:%02d", w, *u.ReminderHour, *u.ReminderMin)
+	query.Set(KeyWhen, fmt.Sprintf("%s@%02d:%02d", w, *u.ReminderHour, *u.ReminderMin))
+	return query, nil
 }
 
 // JSONAttrs stores attributes as JSON values (native types).

--- a/internal/scheme/attrs_test.go
+++ b/internal/scheme/attrs_test.go
@@ -2,6 +2,7 @@ package scheme
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,6 +80,54 @@ func TestJSONAttrs_SetDate(t *testing.T) {
 	assert.Equal(t, "2024-06-15", attrs.Attrs["when"])
 }
 
+func TestURLAttrs_QueryValues(t *testing.T) {
+	t.Run("idempotent with reminder", func(t *testing.T) {
+		attrs := NewURLAttrs()
+		attrs.SetString(KeyWhen, "today")
+		attrs.SetReminder(15, 0)
+
+		first, err := attrs.QueryValues()
+		require.NoError(t, err)
+		second, err := attrs.QueryValues()
+		require.NoError(t, err)
+
+		assert.Equal(t, "today@15:00", first.Get(KeyWhen))
+		assert.Equal(t, first, second, "repeated calls must return identical values")
+		assert.Equal(t, "today", attrs.Params[KeyWhen], "receiver must not be mutated")
+	})
+
+	t.Run("reminder defaults to today", func(t *testing.T) {
+		attrs := NewURLAttrs()
+		attrs.SetReminder(8, 5)
+
+		query, err := attrs.QueryValues()
+		require.NoError(t, err)
+		assert.Equal(t, "today@08:05", query.Get(KeyWhen))
+	})
+
+	t.Run("reminder rejects someday and anytime", func(t *testing.T) {
+		for _, when := range []When{WhenSomeday, WhenAnytime} {
+			attrs := NewURLAttrs()
+			attrs.SetString(KeyWhen, string(when))
+			attrs.SetReminder(9, 0)
+
+			_, err := attrs.QueryValues()
+			assert.ErrorIs(t, err, ErrReminderNeedsDate, "when=%s", when)
+		}
+	})
+
+	t.Run("no reminder passes params through", func(t *testing.T) {
+		attrs := NewURLAttrs()
+		attrs.SetString(KeyTitle, "Task")
+		attrs.SetString(KeyWhen, string(WhenSomeday))
+
+		query, err := attrs.QueryValues()
+		require.NoError(t, err)
+		assert.Equal(t, "Task", query.Get(KeyTitle))
+		assert.Equal(t, "someday", query.Get(KeyWhen))
+	})
+}
+
 // mockBuilder implements AttrBuilder interface for testing generic setters.
 type mockBuilder struct {
 	attrs URLAttrs
@@ -122,6 +171,20 @@ func TestSetStr(t *testing.T) {
 		}
 		result := SetStr(b, TitleParam, string(longTitle))
 		assert.Same(t, b, result)
+		assert.ErrorIs(t, b.err, ErrTitleTooLong)
+	})
+
+	t.Run("multi-byte title counts characters not bytes", func(t *testing.T) {
+		b := newMockBuilder()
+		title := strings.Repeat("中", MaxTitleLength) // 3x the limit in bytes
+		SetStr(b, TitleParam, title)
+		require.NoError(t, b.err)
+		assert.Equal(t, title, b.attrs.Params["title"])
+	})
+
+	t.Run("multi-byte title over rune limit rejected", func(t *testing.T) {
+		b := newMockBuilder()
+		SetStr(b, TitleParam, strings.Repeat("中", MaxTitleLength+1))
 		assert.ErrorIs(t, b.err, ErrTitleTooLong)
 	})
 
@@ -277,6 +340,24 @@ func TestSetStrs(t *testing.T) {
 		result := SetStrs(b, ChecklistItemsParam, items)
 		assert.Same(t, b, result)
 		assert.ErrorIs(t, b.err, ErrTooManyChecklistItems)
+	})
+
+	t.Run("tag containing separator rejected", func(t *testing.T) {
+		b := newMockBuilder()
+		SetStrs(b, TagsParam, []string{"home,work"})
+		assert.ErrorIs(t, b.err, ErrTagContainsComma)
+	})
+
+	t.Run("checklist item containing separator rejected", func(t *testing.T) {
+		b := newMockBuilder()
+		SetStrs(b, ChecklistItemsParam, []string{"line1\nline2"})
+		assert.ErrorIs(t, b.err, ErrChecklistItemContainsNewline)
+	})
+
+	t.Run("JSON storage also validates separators", func(t *testing.T) {
+		b := newMockJSONBuilder()
+		SetStrs(b, TagsParam, []string{"home,work"})
+		assert.ErrorIs(t, b.err, ErrTagContainsComma)
 	})
 }
 

--- a/internal/scheme/builder.go
+++ b/internal/scheme/builder.go
@@ -3,9 +3,9 @@ package scheme
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // addTodoBuilder builds URLs for creating new todos via the add command.
@@ -32,14 +32,20 @@ func (b *addTodoBuilder) Title(title string) TodoAdder {
 }
 
 // Titles sets multiple todo titles (creates multiple todos).
-// Titles are newline-separated.
+// Titles are newline-separated in the URL, so each title must not contain
+// a newline and each title is limited to MaxTitleLength characters.
 func (b *addTodoBuilder) Titles(titles ...string) TodoAdder {
-	combined := strings.Join(titles, "\n")
-	if len(combined) > MaxTitleLength {
-		b.err = ErrTitleTooLong
-		return b
+	for _, title := range titles {
+		if utf8.RuneCountInString(title) > MaxTitleLength {
+			b.err = ErrTitleTooLong
+			return b
+		}
+		if strings.Contains(title, "\n") {
+			b.err = ErrTitleContainsNewline
+			return b
+		}
 	}
-	b.attrs.SetString(KeyTitles, combined)
+	b.attrs.SetString(KeyTitles, strings.Join(titles, "\n"))
 	return b
 }
 
@@ -130,9 +136,10 @@ func (b *addTodoBuilder) Reveal(reveal bool) TodoAdder {
 }
 
 // Reminder sets a reminder time for the todo.
-// The reminder is combined with the scheduling date (When/WhenDate).
+// The reminder is combined with the scheduling date (When/WhenEvening).
 // If no scheduling date is set, defaults to "today".
 // Hour must be 0-23, minute must be 0-59.
+// Combining a reminder with WhenSomeday or WhenAnytime is a build error.
 func (b *addTodoBuilder) Reminder(hour, minute int) TodoAdder {
 	return SetReminder(b, hour, minute)
 }
@@ -150,17 +157,16 @@ func (b *addTodoBuilder) CompletionDate(date time.Time) TodoAdder {
 }
 
 // Build returns the Things URL for creating the todo.
+// Build is pure: it never mutates the builder, so it can be called
+// repeatedly (including via Execute) with identical results.
 func (b *addTodoBuilder) Build() (string, error) {
 	if b.err != nil {
 		return "", b.err
 	}
 
-	// Finalize when parameter with reminder time if set
-	b.attrs.FinalizeWhen()
-
-	query := url.Values{}
-	for k, v := range b.attrs.Params {
-		query.Set(k, v)
+	query, err := b.attrs.QueryValues()
+	if err != nil {
+		return "", err
 	}
 
 	return fmt.Sprintf("things:///%s?%s", CommandAdd, EncodeQuery(query)), nil
@@ -247,9 +253,9 @@ func (b *addProjectBuilder) AreaID(id string) ProjectAdder {
 }
 
 // Todos sets the child todo titles.
+// Titles are newline-separated in the URL, so each title must not contain a newline.
 func (b *addProjectBuilder) Todos(titles ...string) ProjectAdder {
-	b.attrs.SetStrings(KeyTodos, titles, "\n")
-	return b
+	return SetStrs(b, TodosParam, titles)
 }
 
 // Completed sets the completion status.
@@ -271,6 +277,7 @@ func (b *addProjectBuilder) Reveal(reveal bool) ProjectAdder {
 // The reminder is combined with the scheduling date (When).
 // If no scheduling date is set, defaults to "today".
 // Hour must be 0-23, minute must be 0-59.
+// Combining a reminder with WhenSomeday or WhenAnytime is a build error.
 func (b *addProjectBuilder) Reminder(hour, minute int) ProjectAdder {
 	return SetReminder(b, hour, minute)
 }
@@ -286,17 +293,16 @@ func (b *addProjectBuilder) CompletionDate(date time.Time) ProjectAdder {
 }
 
 // Build returns the Things URL for creating the project.
+// Build is pure: it never mutates the builder, so it can be called
+// repeatedly (including via Execute) with identical results.
 func (b *addProjectBuilder) Build() (string, error) {
 	if b.err != nil {
 		return "", b.err
 	}
 
-	// Finalize when parameter with reminder time if set
-	b.attrs.FinalizeWhen()
-
-	query := url.Values{}
-	for k, v := range b.attrs.Params {
-		query.Set(k, v)
+	query, err := b.attrs.QueryValues()
+	if err != nil {
+		return "", err
 	}
 
 	return fmt.Sprintf("things:///%s?%s", CommandAddProject, EncodeQuery(query)), nil

--- a/internal/scheme/builder_test.go
+++ b/internal/scheme/builder_test.go
@@ -1,0 +1,186 @@
+package scheme
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// staticTokenFunc returns a token function that always yields the given token.
+func staticTokenFunc(token string) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) { return token, nil }
+}
+
+// parseQuery extracts the query parameters from a Things URL.
+func parseQuery(t *testing.T, thingsURL string) url.Values {
+	t.Helper()
+	parsed, err := url.Parse(thingsURL)
+	require.NoError(t, err)
+	return parsed.Query()
+}
+
+// Build must be idempotent: calling it twice (as Execute does internally,
+// or on retry) must return byte-identical URLs even with a reminder set.
+func TestBuildIdempotentWithReminder(t *testing.T) {
+	s := New()
+	when := time.Date(2025, time.January, 2, 0, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name    string
+		builder interface{ Build() (string, error) }
+	}{
+		{
+			name:    "todo adder",
+			builder: NewTodoAdder(s).Title("Meeting").When(when).Reminder(15, 0),
+		},
+		{
+			name:    "project adder",
+			builder: NewProjectAdder(s).Title("Project").When(when).Reminder(15, 0),
+		},
+		{
+			name:    "todo updater",
+			builder: NewTodoUpdater(s, staticTokenFunc("token"), "uuid-1").When(when).Reminder(15, 0),
+		},
+		{
+			name:    "project updater",
+			builder: NewProjectUpdater(s, staticTokenFunc("token"), "uuid-1").When(when).Reminder(15, 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first, err := tt.builder.Build()
+			require.NoError(t, err)
+			second, err := tt.builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, first, second, "repeated Build calls must return identical URLs")
+
+			params := parseQuery(t, second)
+			assert.Equal(t, "2025-01-02@15:00", params.Get(KeyWhen),
+				"reminder time must be appended exactly once")
+		})
+	}
+}
+
+// A reminder combined with someday or anytime has no concrete date to attach
+// to, so Build must fail instead of emitting a when value Things cannot parse.
+func TestBuildRejectsReminderWithoutConcreteDate(t *testing.T) {
+	s := New()
+
+	tests := []struct {
+		name    string
+		builder interface{ Build() (string, error) }
+	}{
+		{"todo adder someday", NewTodoAdder(s).Title("T").WhenSomeday().Reminder(9, 0)},
+		{"todo adder anytime", NewTodoAdder(s).Title("T").WhenAnytime().Reminder(9, 0)},
+		{"project adder someday", NewProjectAdder(s).Title("P").WhenSomeday().Reminder(9, 0)},
+		{"project adder anytime", NewProjectAdder(s).Title("P").WhenAnytime().Reminder(9, 0)},
+		{"todo updater someday", NewTodoUpdater(s, staticTokenFunc("token"), "id").WhenSomeday().Reminder(9, 0)},
+		{"todo updater anytime", NewTodoUpdater(s, staticTokenFunc("token"), "id").WhenAnytime().Reminder(9, 0)},
+		{"project updater someday", NewProjectUpdater(s, staticTokenFunc("token"), "id").WhenSomeday().Reminder(9, 0)},
+		{"project updater anytime", NewProjectUpdater(s, staticTokenFunc("token"), "id").WhenAnytime().Reminder(9, 0)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.builder.Build()
+			assert.ErrorIs(t, err, ErrReminderNeedsDate)
+		})
+	}
+}
+
+// Evening carries a concrete scheduling slot, so reminders remain allowed.
+func TestBuildAllowsReminderWithEvening(t *testing.T) {
+	thingsURL, err := NewTodoAdder(New()).Title("T").WhenEvening().Reminder(18, 30).Build()
+	require.NoError(t, err)
+	assert.Equal(t, "evening@18:30", parseQuery(t, thingsURL).Get(KeyWhen))
+}
+
+// Length limits are documented in characters; multi-byte input must not be
+// rejected at one third of the limit.
+func TestLengthLimitsCountCharactersNotBytes(t *testing.T) {
+	s := New()
+	cjkTitle := strings.Repeat("中", 2000)  // 2000 runes, 6000 bytes
+	cjkNotes := strings.Repeat("中", 10000) // 10000 runes, 30000 bytes
+
+	t.Run("todo adder title", func(t *testing.T) {
+		thingsURL, err := NewTodoAdder(s).Title(cjkTitle).Build()
+		require.NoError(t, err)
+		assert.Equal(t, cjkTitle, parseQuery(t, thingsURL).Get(KeyTitle))
+	})
+
+	t.Run("todo adder notes", func(t *testing.T) {
+		_, err := NewTodoAdder(s).Title("T").Notes(cjkNotes).Build()
+		require.NoError(t, err)
+	})
+
+	t.Run("titles are validated per title", func(t *testing.T) {
+		thingsURL, err := NewTodoAdder(s).Titles(cjkTitle, cjkTitle, cjkTitle).Build()
+		require.NoError(t, err)
+		assert.Equal(t, strings.Repeat(cjkTitle+"\n", 2)+cjkTitle,
+			parseQuery(t, thingsURL).Get(KeyTitles))
+	})
+
+	t.Run("batch todo title", func(t *testing.T) {
+		item := newBatchTodoBuilder()
+		item.Title(cjkTitle)
+		require.NoError(t, item.err)
+	})
+
+	t.Run("rune limit still enforced", func(t *testing.T) {
+		_, err := NewTodoAdder(s).Title(strings.Repeat("中", MaxTitleLength+1)).Build()
+		require.ErrorIs(t, err, ErrTitleTooLong)
+
+		_, err = NewTodoAdder(s).Titles(strings.Repeat("a", MaxTitleLength+1)).Build()
+		assert.ErrorIs(t, err, ErrTitleTooLong)
+	})
+}
+
+// Values containing the join separator would silently split into multiple
+// items; builders must reject them at build time.
+func TestSeparatorInjectionRejected(t *testing.T) {
+	s := New()
+
+	tests := []struct {
+		name    string
+		builder interface{ Build() (string, error) }
+		wantErr error
+	}{
+		{"todo adder tag with comma", NewTodoAdder(s).Title("T").Tags("home,work"), ErrTagContainsComma},
+		{"project adder tag with comma", NewProjectAdder(s).Title("P").Tags("a,b"), ErrTagContainsComma},
+		{"todo updater add-tags with comma", NewTodoUpdater(s, staticTokenFunc("token"), "id").AddTags("a,b"), ErrTagContainsComma},
+		{"checklist item with newline", NewTodoAdder(s).Title("T").ChecklistItems("line1\nline2"), ErrChecklistItemContainsNewline},
+		{"prepend checklist item with newline", NewTodoUpdater(s, staticTokenFunc("token"), "id").PrependChecklistItems("a\nb"), ErrChecklistItemContainsNewline},
+		{"append checklist item with newline", NewTodoUpdater(s, staticTokenFunc("token"), "id").AppendChecklistItems("a\nb"), ErrChecklistItemContainsNewline},
+		{"titles with newline", NewTodoAdder(s).Titles("Task 1\nTask 2"), ErrTitleContainsNewline},
+		{"project todos with newline", NewProjectAdder(s).Title("P").Todos("Task 1\nTask 2"), ErrTitleContainsNewline},
+		{"show filter tag with comma", NewShowNavigator(s).List(ListToday).Filter("home,work"), ErrTagContainsComma},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.builder.Build()
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+// Separator-free values must keep working after the injection validation.
+func TestSeparatorValidationAllowsCleanValues(t *testing.T) {
+	s := New()
+
+	thingsURL, err := NewTodoAdder(s).Title("T").Tags("home", "work").ChecklistItems("one", "two").Build()
+	require.NoError(t, err)
+	params := parseQuery(t, thingsURL)
+	assert.Equal(t, "home,work", params.Get(KeyTags))
+	assert.Equal(t, "one\ntwo", params.Get(KeyChecklistItems))
+
+	thingsURL, err = NewShowNavigator(s).List(ListToday).Filter("home", "work").Build()
+	require.NoError(t, err)
+	assert.Equal(t, "home,work", parseQuery(t, thingsURL).Get(KeyFilter))
+}

--- a/internal/scheme/errors.go
+++ b/internal/scheme/errors.go
@@ -4,8 +4,9 @@ import "errors"
 
 // Operation errors for URL scheme builders.
 var (
-	// ErrEmptyToken is returned when an empty token is provided to WithToken.
-	ErrEmptyToken = errors.New("things3: empty token provided to WithToken")
+	// ErrEmptyToken is returned when the auth token resolves to empty for an
+	// operation that requires one (update commands and batch updates).
+	ErrEmptyToken = errors.New("things3: auth token is empty")
 	// ErrIDRequired is returned when id is missing for an update operation.
 	ErrIDRequired = errors.New("things3: id required for update operation")
 	// ErrNoJSONItems is returned when building a JSON URL with no items.

--- a/internal/scheme/json.go
+++ b/internal/scheme/json.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -479,34 +478,32 @@ func (b *authBatchBuilder) Reveal(reveal bool) AuthBatchCreator {
 	return b
 }
 
-// Build returns the Things URL for the JSON batch operation.
-// If token is not set but tokenFunc is provided, it will fetch the token using context.Background().
-// For explicit context control, use Execute() instead.
-func (b *authBatchBuilder) Build() (string, error) {
+// hasUpdates reports whether any item in the batch is an update operation.
+func (b *authBatchBuilder) hasUpdates() bool {
+	for _, item := range b.items {
+		if item.Operation == JSONOperationUpdate {
+			return true
+		}
+	}
+	return false
+}
+
+// build resolves the auth token (only when the batch contains updates)
+// and constructs the JSON batch URL.
+func (b *authBatchBuilder) build(ctx context.Context) (string, error) {
 	if b.err != nil {
 		return "", b.err
-	}
-	// Lazy load token if needed
-	if b.token == "" && b.tokenFunc != nil {
-		t, err := b.tokenFunc(context.Background())
-		if err != nil {
-			return "", err
-		}
-		b.token = t
-	}
-	if b.token == "" {
-		return "", ErrEmptyToken
 	}
 	if len(b.items) == 0 {
 		return "", ErrNoJSONItems
 	}
 
-	// Check if any items are updates
-	hasUpdates := false
-	for _, item := range b.items {
-		if item.Operation == JSONOperationUpdate {
-			hasUpdates = true
-			break
+	// The auth-token parameter is only required for update operations,
+	// so create-only batches never need a token.
+	hasUpdates := b.hasUpdates()
+	if hasUpdates {
+		if err := resolveToken(ctx, &b.token, b.tokenFunc); err != nil {
+			return "", err
 		}
 	}
 
@@ -540,27 +537,22 @@ func (b *authBatchBuilder) Build() (string, error) {
 	return fmt.Sprintf("things:///%s?%s", CommandJSON, EncodeQuery(query)), nil
 }
 
+// Build returns the Things URL for the JSON batch operation.
+// A token is required only when the batch contains update operations.
+// If the token has not been resolved yet, the token function runs without a
+// caller context; use Execute for context-aware token loading.
+func (b *authBatchBuilder) Build() (string, error) {
+	return b.build(context.Background())
+}
+
 // Execute builds and executes the JSON batch URL.
 // Returns an error if the URL cannot be built or executed.
-// If token is not set but tokenFunc is provided, it will fetch the token first.
+// The auth token is resolved at most once, using the provided context,
+// and only when the batch contains update operations.
 func (b *authBatchBuilder) Execute(ctx context.Context) error {
-	// Lazy load token if needed
-	if b.token == "" && b.tokenFunc != nil {
-		token, err := b.tokenFunc(ctx)
-		if err != nil {
-			return err
-		}
-		b.token = token
-	}
-	uri, err := b.Build()
+	uri, err := b.build(ctx)
 	if err != nil {
 		return err
 	}
 	return b.scheme.Execute(ctx, uri)
-}
-
-// Headings creates heading entries for a project's items.
-// Used within batchProjectBuilder.Todos to organize todos under headings.
-func Headings(headings ...string) string {
-	return strings.Join(headings, "\n")
 }

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -1,9 +1,11 @@
 package scheme
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // Scheme provides URL scheme execution for Things 3.
@@ -21,20 +23,41 @@ func New(opts ...Option) *Scheme {
 	return s
 }
 
+// wrapExecError combines a command failure with its captured stderr output,
+// so causes like AppleEvents permission denials remain distinguishable from
+// malformed URLs. Returns nil when err is nil; the original error stays
+// matchable via errors.Is/As.
+func wrapExecError(err error, stderr []byte) error {
+	if err == nil {
+		return nil
+	}
+	if msg := strings.TrimSpace(string(stderr)); msg != "" {
+		return fmt.Errorf("things3: URL scheme execution failed: %w: %s", err, msg)
+	}
+	return fmt.Errorf("things3: URL scheme execution failed: %w", err)
+}
+
+// run executes the command with stderr captured and wraps any failure.
+func run(cmd *exec.Cmd) error {
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	return wrapExecError(cmd.Run(), stderr.Bytes())
+}
+
 // Execute opens a Things URL scheme for create/update operations.
 func (s *Scheme) Execute(ctx context.Context, uri string) error {
 	if s.foreground {
-		return exec.CommandContext(ctx, "open", uri).Run()
+		return run(exec.CommandContext(ctx, "open", uri))
 	}
 	script := fmt.Sprintf(`tell application "Things3" to open location %q`, uri)
-	return exec.CommandContext(ctx, "osascript", "-e", script).Run()
+	return run(exec.CommandContext(ctx, "osascript", "-e", script))
 }
 
 // ExecuteNavigation opens a Things URL scheme for navigation operations.
 func (s *Scheme) ExecuteNavigation(ctx context.Context, uri string) error {
 	if !s.background {
-		return exec.CommandContext(ctx, "open", uri).Run()
+		return run(exec.CommandContext(ctx, "open", uri))
 	}
 	script := fmt.Sprintf(`tell application "Things3" to open location %q`, uri)
-	return exec.CommandContext(ctx, "osascript", "-e", script).Run()
+	return run(exec.CommandContext(ctx, "osascript", "-e", script))
 }

--- a/internal/scheme/scheme_test.go
+++ b/internal/scheme/scheme_test.go
@@ -1,0 +1,49 @@
+package scheme
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapExecError(t *testing.T) {
+	execErr := errors.New("exit status 1")
+
+	t.Run("nil error returns nil", func(t *testing.T) {
+		assert.NoError(t, wrapExecError(nil, []byte("ignored output")))
+	})
+
+	tests := []struct {
+		name       string
+		stderr     string
+		wantStderr string
+	}{
+		{
+			name:       "stderr included in error message",
+			stderr:     "execution error: Things3 got an error: AppleEvent handler failed. (-10000)\n",
+			wantStderr: "AppleEvent handler failed",
+		},
+		{
+			name:   "empty stderr still wraps error",
+			stderr: "",
+		},
+		{
+			name:   "whitespace-only stderr treated as empty",
+			stderr: "  \n\t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapExecError(execErr, []byte(tt.stderr))
+			require.Error(t, got)
+			require.ErrorIs(t, got, execErr, "original error must stay matchable")
+			assert.Contains(t, got.Error(), execErr.Error())
+			if tt.wantStderr != "" {
+				assert.Contains(t, got.Error(), tt.wantStderr)
+			}
+		})
+	}
+}

--- a/internal/scheme/show.go
+++ b/internal/scheme/show.go
@@ -11,6 +11,7 @@ import (
 type showBuilder struct {
 	scheme *Scheme
 	params map[string]string
+	err    error
 }
 
 // NewShowNavigator creates a new ShowNavigator for navigation operations.
@@ -38,13 +39,24 @@ func (b *showBuilder) Query(query string) ShowNavigator {
 }
 
 // Filter filters the displayed items by tags.
+// Tags are comma-separated in the URL, so a tag must not contain a comma.
 func (b *showBuilder) Filter(tags ...string) ShowNavigator {
+	for _, tag := range tags {
+		if strings.Contains(tag, ",") {
+			b.err = ErrTagContainsComma
+			return b
+		}
+	}
 	b.params[KeyFilter] = strings.Join(tags, ",")
 	return b
 }
 
 // Build returns the Things URL for the show command.
 func (b *showBuilder) Build() (string, error) {
+	if b.err != nil {
+		return "", b.err
+	}
+
 	query := url.Values{}
 	for k, v := range b.params {
 		query.Set(k, v)

--- a/internal/scheme/token_test.go
+++ b/internal/scheme/token_test.go
@@ -1,0 +1,134 @@
+package scheme
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenRecorder records how often the token function ran and with which context.
+type tokenRecorder struct {
+	calls int
+	ctx   context.Context
+	token string
+	err   error
+}
+
+func (r *tokenRecorder) fn(ctx context.Context) (string, error) {
+	r.calls++
+	r.ctx = ctx
+	return r.token, r.err
+}
+
+type ctxKey struct{}
+
+// An empty token from the token function must fail immediately on the first
+// fetch: no second fetch, and the caller's context must be used.
+func TestExecuteEmptyTokenFailsOnFirstFetch(t *testing.T) {
+	s := New()
+	ctx := context.WithValue(t.Context(), ctxKey{}, "marker")
+
+	t.Run("todo updater", func(t *testing.T) {
+		rec := &tokenRecorder{}
+		err := NewTodoUpdater(s, rec.fn, "uuid").Completed(true).Execute(ctx)
+		require.ErrorIs(t, err, ErrEmptyToken)
+		assert.Equal(t, 1, rec.calls, "token function must run exactly once")
+		assert.Equal(t, "marker", rec.ctx.Value(ctxKey{}), "caller context must be passed to the token function")
+	})
+
+	t.Run("project updater", func(t *testing.T) {
+		rec := &tokenRecorder{}
+		err := NewProjectUpdater(s, rec.fn, "uuid").Completed(true).Execute(ctx)
+		require.ErrorIs(t, err, ErrEmptyToken)
+		assert.Equal(t, 1, rec.calls)
+		assert.Equal(t, "marker", rec.ctx.Value(ctxKey{}))
+	})
+
+	t.Run("auth batch with update", func(t *testing.T) {
+		rec := &tokenRecorder{}
+		err := NewAuthBatch(s, rec.fn).
+			UpdateTodo("uuid", func(todo BatchTodoConfigurator) { todo.Completed(true) }).
+			Execute(ctx)
+		require.ErrorIs(t, err, ErrEmptyToken)
+		assert.Equal(t, 1, rec.calls)
+		assert.Equal(t, "marker", rec.ctx.Value(ctxKey{}))
+	})
+}
+
+// The corrected error text must not reference the nonexistent WithToken API.
+func TestEmptyTokenErrorText(t *testing.T) {
+	assert.NotContains(t, ErrEmptyToken.Error(), "WithToken")
+}
+
+// Token function errors must surface unchanged from Build.
+func TestBuildPropagatesTokenFuncError(t *testing.T) {
+	s := New()
+	tokenErr := errors.New("token store unavailable")
+	failing := func(context.Context) (string, error) { return "", tokenErr }
+
+	_, err := NewTodoUpdater(s, failing, "uuid").Completed(true).Build()
+	require.ErrorIs(t, err, tokenErr)
+
+	_, err = NewProjectUpdater(s, failing, "uuid").Completed(true).Build()
+	assert.ErrorIs(t, err, tokenErr)
+}
+
+// A create-only auth batch never emits auth-token, so it must build even when
+// the token function fails; a batch containing an update must still fail.
+func TestAuthBatchTokenOnlyRequiredForUpdates(t *testing.T) {
+	s := New()
+	tokenErr := errors.New("token store unavailable")
+
+	t.Run("create-only builds despite failing token func", func(t *testing.T) {
+		rec := &tokenRecorder{err: tokenErr}
+		thingsURL, err := NewAuthBatch(s, rec.fn).
+			AddTodo(func(todo BatchTodoConfigurator) { todo.Title("Test") }).
+			Build()
+		require.NoError(t, err)
+		assert.Zero(t, rec.calls, "create-only batches must not fetch a token")
+		assert.False(t, parseQuery(t, thingsURL).Has(KeyAuthToken))
+	})
+
+	t.Run("update batch fails with failing token func", func(t *testing.T) {
+		rec := &tokenRecorder{err: tokenErr}
+		_, err := NewAuthBatch(s, rec.fn).
+			UpdateTodo("uuid", func(todo BatchTodoConfigurator) { todo.Completed(true) }).
+			Build()
+		require.ErrorIs(t, err, tokenErr)
+		assert.Equal(t, 1, rec.calls)
+	})
+
+	t.Run("update batch fails with empty token", func(t *testing.T) {
+		_, err := NewAuthBatch(s, staticTokenFunc("")).
+			UpdateTodo("uuid", func(todo BatchTodoConfigurator) { todo.Completed(true) }).
+			Build()
+		assert.ErrorIs(t, err, ErrEmptyToken)
+	})
+
+	t.Run("mixed batch includes token", func(t *testing.T) {
+		thingsURL, err := NewAuthBatch(s, staticTokenFunc("secret")).
+			AddTodo(func(todo BatchTodoConfigurator) { todo.Title("New") }).
+			UpdateTodo("uuid", func(todo BatchTodoConfigurator) { todo.Completed(true) }).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "secret", parseQuery(t, thingsURL).Get(KeyAuthToken))
+	})
+}
+
+// The token is resolved once and reused by subsequent Build calls.
+func TestTokenResolvedOnce(t *testing.T) {
+	s := New()
+	rec := &tokenRecorder{token: "secret"}
+	builder := NewTodoUpdater(s, rec.fn, "uuid").Completed(true)
+
+	first, err := builder.Build()
+	require.NoError(t, err)
+	second, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, rec.calls, "token must be cached after the first fetch")
+}

--- a/internal/scheme/update.go
+++ b/internal/scheme/update.go
@@ -7,8 +7,8 @@ import (
 )
 
 // resolveToken ensures a non-empty auth token is cached in *token.
-// The token function runs at most once per builder: an error or an empty
-// result fails immediately instead of being retried on a later Build call.
+// A successful fetch is cached and reused by later Build calls; a failed or
+// empty fetch returns an error immediately and is retried on the next Build.
 func resolveToken(ctx context.Context, token *string, tokenFunc func(context.Context) (string, error)) error {
 	if *token != "" {
 		return nil

--- a/internal/scheme/update.go
+++ b/internal/scheme/update.go
@@ -3,42 +3,39 @@ package scheme
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"time"
 )
 
-// buildUpdateURL is a shared helper for building update URLs.
-// It handles lazy token loading, validation, and URL construction.
-func buildUpdateURL(
-	token *string,
-	tokenFunc func(context.Context) (string, error),
-	id string,
-	attrs *URLAttrs,
-	command Command,
-	validateFn func() error,
-) (string, error) {
-	// Lazy load token if needed
-	if *token == "" && tokenFunc != nil {
-		t, err := tokenFunc(context.Background())
-		if err != nil {
-			return "", err
-		}
-		*token = t
+// resolveToken ensures a non-empty auth token is cached in *token.
+// The token function runs at most once per builder: an error or an empty
+// result fails immediately instead of being retried on a later Build call.
+func resolveToken(ctx context.Context, token *string, tokenFunc func(context.Context) (string, error)) error {
+	if *token != "" {
+		return nil
 	}
+	if tokenFunc == nil {
+		return ErrEmptyToken
+	}
+	t, err := tokenFunc(ctx)
+	if err != nil {
+		return err
+	}
+	if t == "" {
+		return ErrEmptyToken
+	}
+	*token = t
+	return nil
+}
 
-	if err := validateFn(); err != nil {
+// buildUpdateURL constructs an update URL from already-validated inputs.
+// It is pure: the attribute store is never mutated.
+func buildUpdateURL(id, token string, attrs *URLAttrs, command Command) (string, error) {
+	query, err := attrs.QueryValues()
+	if err != nil {
 		return "", err
 	}
-
-	// Finalize when parameter with reminder time if set
-	attrs.FinalizeWhen()
-
-	query := url.Values{}
 	query.Set(KeyID, id)
-	query.Set(KeyAuthToken, *token)
-	for k, v := range attrs.Params {
-		query.Set(k, v)
-	}
+	query.Set(KeyAuthToken, token)
 
 	return fmt.Sprintf("things:///%s?%s", command, EncodeQuery(query)), nil
 }
@@ -115,6 +112,7 @@ func (b *updateTodoBuilder) WhenSomeday() TodoUpdater {
 // The reminder is combined with the scheduling date (When).
 // If no scheduling date is set, defaults to "today".
 // Hour must be 0-23, minute must be 0-59.
+// Combining a reminder with WhenSomeday or WhenAnytime is a build error.
 func (b *updateTodoBuilder) Reminder(hour, minute int) TodoUpdater {
 	return SetReminder(b, hour, minute)
 }
@@ -211,35 +209,36 @@ func (b *updateTodoBuilder) validate() error {
 	if b.err != nil {
 		return b.err
 	}
-	if b.token == "" {
-		return ErrEmptyToken
-	}
 	if b.id == "" {
 		return ErrIDRequired
 	}
 	return nil
 }
 
+// build validates the builder, resolves the auth token once using ctx,
+// and constructs the update URL.
+func (b *updateTodoBuilder) build(ctx context.Context) (string, error) {
+	if err := b.validate(); err != nil {
+		return "", err
+	}
+	if err := resolveToken(ctx, &b.token, b.tokenFunc); err != nil {
+		return "", err
+	}
+	return buildUpdateURL(b.id, b.token, &b.attrs, CommandUpdate)
+}
+
 // Build returns the Things URL for updating the todo.
-// If token is not set but tokenFunc is provided, it will fetch the token using context.Background().
-// For explicit context control, use Execute() instead.
+// If the token has not been resolved yet, the token function runs without a
+// caller context; use Execute for context-aware token loading.
 func (b *updateTodoBuilder) Build() (string, error) {
-	return buildUpdateURL(&b.token, b.tokenFunc, b.id, &b.attrs, CommandUpdate, b.validate)
+	return b.build(context.Background())
 }
 
 // Execute builds and executes the update URL.
 // Returns an error if the URL cannot be built or executed.
-// If token is not set but tokenFunc is provided, it will fetch the token first.
+// The auth token is resolved at most once, using the provided context.
 func (b *updateTodoBuilder) Execute(ctx context.Context) error {
-	// Lazy load token if needed
-	if b.token == "" && b.tokenFunc != nil {
-		token, err := b.tokenFunc(ctx)
-		if err != nil {
-			return err
-		}
-		b.token = token
-	}
-	uri, err := b.Build()
+	uri, err := b.build(ctx)
 	if err != nil {
 		return err
 	}
@@ -318,6 +317,7 @@ func (b *updateProjectBuilder) WhenSomeday() ProjectUpdater {
 // The reminder is combined with the scheduling date (When).
 // If no scheduling date is set, defaults to "today".
 // Hour must be 0-23, minute must be 0-59.
+// Combining a reminder with WhenSomeday or WhenAnytime is a build error.
 func (b *updateProjectBuilder) Reminder(hour, minute int) ProjectUpdater {
 	return SetReminder(b, hour, minute)
 }
@@ -376,35 +376,36 @@ func (b *updateProjectBuilder) validate() error {
 	if b.err != nil {
 		return b.err
 	}
-	if b.token == "" {
-		return ErrEmptyToken
-	}
 	if b.id == "" {
 		return ErrIDRequired
 	}
 	return nil
 }
 
+// build validates the builder, resolves the auth token once using ctx,
+// and constructs the update URL.
+func (b *updateProjectBuilder) build(ctx context.Context) (string, error) {
+	if err := b.validate(); err != nil {
+		return "", err
+	}
+	if err := resolveToken(ctx, &b.token, b.tokenFunc); err != nil {
+		return "", err
+	}
+	return buildUpdateURL(b.id, b.token, &b.attrs, CommandUpdateProject)
+}
+
 // Build returns the Things URL for updating the project.
-// If token is not set but tokenFunc is provided, it will fetch the token using context.Background().
-// For explicit context control, use Execute() instead.
+// If the token has not been resolved yet, the token function runs without a
+// caller context; use Execute for context-aware token loading.
 func (b *updateProjectBuilder) Build() (string, error) {
-	return buildUpdateURL(&b.token, b.tokenFunc, b.id, &b.attrs, CommandUpdateProject, b.validate)
+	return b.build(context.Background())
 }
 
 // Execute builds and executes the update URL.
 // Returns an error if the URL cannot be built or executed.
-// If token is not set but tokenFunc is provided, it will fetch the token first.
+// The auth token is resolved at most once, using the provided context.
 func (b *updateProjectBuilder) Execute(ctx context.Context) error {
-	// Lazy load token if needed
-	if b.token == "" && b.tokenFunc != nil {
-		token, err := b.tokenFunc(ctx)
-		if err != nil {
-			return err
-		}
-		b.token = token
-	}
-	uri, err := b.Build()
+	uri, err := b.build(ctx)
 	if err != nil {
 		return err
 	}

--- a/query.go
+++ b/query.go
@@ -12,6 +12,11 @@ import (
 // =============================================================================
 
 // taskQuery holds the shared query state for todo, project, and heading builders.
+//
+// Builders are copy-on-write: every chainable method shallow-copies the state
+// and returns a new builder, so a builder value can be forked into independent
+// queries. The shallow copy is safe because setters always replace whole
+// pointer fields instead of mutating through them.
 type taskQuery struct {
 	database         *db
 	filter           database.TaskFilter
@@ -24,14 +29,14 @@ type taskQuery struct {
 
 // todoQuery provides a fluent interface for building todo queries.
 type todoQuery struct {
-	inner *taskQuery
+	inner taskQuery
 }
 
 // Todos creates a new todoQuery for querying todos.
 func (d *db) Todos() *todoQuery {
 	taskType := int(taskTypeTodo)
 	return &todoQuery{
-		inner: &taskQuery{
+		inner: taskQuery{
 			database: d,
 			filter: database.TaskFilter{
 				Index:    database.IndexDefault,
@@ -41,147 +46,146 @@ func (d *db) Todos() *todoQuery {
 	}
 }
 
+// clone returns a shallow copy of the query for copy-on-write chaining.
+func (q *todoQuery) clone() *todoQuery {
+	c := *q
+	return &c
+}
+
+// withFilter clones the query, applies mutate to the clone's filter, and
+// returns the clone.
+func (q *todoQuery) withFilter(mutate func(*database.TaskFilter)) TodoQueryBuilder {
+	c := q.clone()
+	mutate(&c.inner.filter)
+	return c
+}
+
 // WithUUID filters todos by UUID (exact match).
 func (q *todoQuery) WithUUID(uuid string) TodoQueryBuilder {
-	q.inner.filter.UUID = &uuid
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.UUID = &uuid })
 }
 
 // WithUUIDPrefix filters todos by UUID prefix (LIKE match).
 func (q *todoQuery) WithUUIDPrefix(prefix string) TodoQueryBuilder {
-	q.inner.filter.UUIDPrefix = &prefix
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.UUIDPrefix = &prefix })
 }
 
 // WithTitle filters todos by title (keyword match).
 func (q *todoQuery) WithTitle(title string) TodoQueryBuilder {
-	q.inner.filter.Title = &title
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.Title = &title })
 }
 
 // Status returns a StatusFilter for type-safe status filtering.
 func (q *todoQuery) Status() StatusFilter[TodoQueryBuilder] {
-	return &statusFilter[TodoQueryBuilder]{query: q.inner, parent: q}
+	return &statusFilter[TodoQueryBuilder]{with: q.withFilter}
 }
 
 // Start returns a StartFilter for type-safe start bucket filtering.
 func (q *todoQuery) Start() StartFilter[TodoQueryBuilder] {
-	return &startFilter[TodoQueryBuilder]{query: q.inner, parent: q}
+	return &startFilter[TodoQueryBuilder]{with: q.withFilter}
 }
 
 // Trashed filters todos by trash status.
 func (q *todoQuery) Trashed(trashed bool) TodoQueryBuilder {
-	q.inner.filter.Trashed = &trashed
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.Trashed = &trashed })
 }
 
 // InArea filters todos by a specific area UUID.
 func (q *todoQuery) InArea(uuid string) TodoQueryBuilder {
-	q.inner.filter.AreaUUID = &uuid
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.AreaUUID = &uuid })
 }
 
 // HasArea filters todos by whether they have an area.
 func (q *todoQuery) HasArea(has bool) TodoQueryBuilder {
-	q.inner.filter.HasArea = &has
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.HasArea = &has })
 }
 
 // InProject filters todos by a specific project UUID.
 func (q *todoQuery) InProject(uuid string) TodoQueryBuilder {
-	q.inner.filter.ProjectUUID = &uuid
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.ProjectUUID = &uuid })
 }
 
 // HasProject filters todos by whether they have a project.
 func (q *todoQuery) HasProject(has bool) TodoQueryBuilder {
-	q.inner.filter.HasProject = &has
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.HasProject = &has })
 }
 
 // InHeading filters todos by a specific heading UUID.
 func (q *todoQuery) InHeading(uuid string) TodoQueryBuilder {
-	q.inner.filter.HeadingUUID = &uuid
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.HeadingUUID = &uuid })
 }
 
 // HasHeading filters todos by whether they have a heading.
 func (q *todoQuery) HasHeading(has bool) TodoQueryBuilder {
-	q.inner.filter.HasHeading = &has
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.HasHeading = &has })
 }
 
 // InTag filters todos by a specific tag title.
 func (q *todoQuery) InTag(title string) TodoQueryBuilder {
-	q.inner.filter.TagTitle = &title
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.TagTitle = &title })
 }
 
 // HasTag filters todos by whether they have any tags.
 func (q *todoQuery) HasTag(has bool) TodoQueryBuilder {
-	q.inner.filter.HasTags = &has
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.HasTags = &has })
 }
 
 // StartDate returns a DateFilter for start date filtering.
 func (q *todoQuery) StartDate() DateFilter[TodoQueryBuilder] {
-	return &dateFilter[TodoQueryBuilder]{query: q.inner, parent: q, field: dateFieldStartDate}
+	return &dateFilter[TodoQueryBuilder]{with: q.withFilter, field: dateFieldStartDate}
 }
 
 // StopDate returns a DateFilter for stop date filtering.
 func (q *todoQuery) StopDate() DateFilter[TodoQueryBuilder] {
-	return &dateFilter[TodoQueryBuilder]{query: q.inner, parent: q, field: dateFieldStopDate}
+	return &dateFilter[TodoQueryBuilder]{with: q.withFilter, field: dateFieldStopDate}
 }
 
 // Deadline returns a DateFilter for deadline filtering.
 func (q *todoQuery) Deadline() DateFilter[TodoQueryBuilder] {
-	return &dateFilter[TodoQueryBuilder]{query: q.inner, parent: q, field: dateFieldDeadline}
+	return &dateFilter[TodoQueryBuilder]{with: q.withFilter, field: dateFieldDeadline}
 }
 
 // DeadlineSuppressed filters todos by whether the deadline has been suppressed.
 func (q *todoQuery) DeadlineSuppressed(suppressed bool) TodoQueryBuilder {
-	q.inner.filter.DeadlineSuppressed = &suppressed
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.DeadlineSuppressed = &suppressed })
 }
 
 // CreatedAfter filters todos created after the specified time.
 func (q *todoQuery) CreatedAfter(t time.Time) TodoQueryBuilder {
-	q.inner.filter.CreatedAfter = &t
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.CreatedAfter = &t })
 }
 
 // Search filters todos by a search query.
 func (q *todoQuery) Search(query string) TodoQueryBuilder {
-	q.inner.filter.SearchQuery = &query
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.SearchQuery = &query })
 }
 
 // OrderByTodayIndex orders results by today index instead of default index.
 func (q *todoQuery) OrderByTodayIndex() TodoQueryBuilder {
-	q.inner.filter.Index = database.IndexToday
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.Index = database.IndexToday })
 }
 
 // Limit restricts the maximum number of results returned.
 func (q *todoQuery) Limit(n int) TodoQueryBuilder {
-	q.inner.filter.Limit = &n
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.Limit = &n })
 }
 
 // IncludeChecklist opts in to loading checklist items for each todo.
 func (q *todoQuery) IncludeChecklist() TodoQueryBuilder {
-	q.inner.includeChecklist = true
-	return q
+	c := q.clone()
+	c.inner.includeChecklist = true
+	return c
 }
 
 // All executes the query and returns all matching todos.
+// The result is never nil; an empty result encodes as a JSON array.
 func (q *todoQuery) All(ctx context.Context) ([]Todo, error) {
 	rows, err := q.inner.database.inner.QueryTasks(ctx, &q.inner.filter)
 	if err != nil {
 		return nil, err
 	}
 
-	var todos []Todo
+	todos := make([]Todo, 0, len(rows))
 	for i := range rows {
 		todo := convertTaskRowToTodo(&rows[i])
 
@@ -210,11 +214,15 @@ func (q *todoQuery) All(ctx context.Context) ([]Todo, error) {
 }
 
 // First executes the query and returns the first matching todo.
+// Unlike All, First always loads the checklist and fetches at most one row.
+// Both adjustments apply to a private copy, leaving the receiver unchanged.
 func (q *todoQuery) First(ctx context.Context) (*Todo, error) {
-	// For single todo fetch, always include checklist
-	q.inner.includeChecklist = true
+	one := 1
+	c := q.clone()
+	c.inner.includeChecklist = true
+	c.inner.filter.Limit = &one
 
-	todos, err := q.All(ctx)
+	todos, err := c.All(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -235,14 +243,14 @@ func (q *todoQuery) Count(ctx context.Context) (int, error) {
 
 // projectQuery provides a fluent interface for building project queries.
 type projectQuery struct {
-	inner *taskQuery
+	inner taskQuery
 }
 
 // Projects creates a new projectQuery for querying projects.
 func (d *db) Projects() *projectQuery {
 	taskType := int(taskTypeProject)
 	return &projectQuery{
-		inner: &taskQuery{
+		inner: taskQuery{
 			database: d,
 			filter: database.TaskFilter{
 				Index:    database.IndexDefault,
@@ -252,99 +260,109 @@ func (d *db) Projects() *projectQuery {
 	}
 }
 
+// clone returns a shallow copy of the query for copy-on-write chaining.
+func (q *projectQuery) clone() *projectQuery {
+	c := *q
+	return &c
+}
+
+// withFilter clones the query, applies mutate to the clone's filter, and
+// returns the clone.
+func (q *projectQuery) withFilter(mutate func(*database.TaskFilter)) ProjectQueryBuilder {
+	c := q.clone()
+	mutate(&c.inner.filter)
+	return c
+}
+
 // WithUUID filters projects by UUID (exact match).
 func (q *projectQuery) WithUUID(uuid string) ProjectQueryBuilder {
-	q.inner.filter.UUID = &uuid
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.UUID = &uuid })
+}
+
+// WithUUIDPrefix filters projects by UUID prefix (LIKE match).
+func (q *projectQuery) WithUUIDPrefix(prefix string) ProjectQueryBuilder {
+	return q.withFilter(func(f *database.TaskFilter) { f.UUIDPrefix = &prefix })
 }
 
 // WithTitle filters projects by title (keyword match).
 func (q *projectQuery) WithTitle(title string) ProjectQueryBuilder {
-	q.inner.filter.Title = &title
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.Title = &title })
 }
 
 // Status returns a StatusFilter for type-safe status filtering.
 func (q *projectQuery) Status() StatusFilter[ProjectQueryBuilder] {
-	return &statusFilter[ProjectQueryBuilder]{query: q.inner, parent: q}
+	return &statusFilter[ProjectQueryBuilder]{with: q.withFilter}
 }
 
 // Start returns a StartFilter for type-safe start bucket filtering.
 func (q *projectQuery) Start() StartFilter[ProjectQueryBuilder] {
-	return &startFilter[ProjectQueryBuilder]{query: q.inner, parent: q}
+	return &startFilter[ProjectQueryBuilder]{with: q.withFilter}
 }
 
 // Trashed filters projects by trash status.
 func (q *projectQuery) Trashed(trashed bool) ProjectQueryBuilder {
-	q.inner.filter.Trashed = &trashed
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.Trashed = &trashed })
 }
 
 // InArea filters projects by a specific area UUID.
 func (q *projectQuery) InArea(uuid string) ProjectQueryBuilder {
-	q.inner.filter.AreaUUID = &uuid
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.AreaUUID = &uuid })
 }
 
 // HasArea filters projects by whether they have an area.
 func (q *projectQuery) HasArea(has bool) ProjectQueryBuilder {
-	q.inner.filter.HasArea = &has
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.HasArea = &has })
 }
 
 // InTag filters projects by a specific tag title.
 func (q *projectQuery) InTag(title string) ProjectQueryBuilder {
-	q.inner.filter.TagTitle = &title
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.TagTitle = &title })
 }
 
 // HasTag filters projects by whether they have any tags.
 func (q *projectQuery) HasTag(has bool) ProjectQueryBuilder {
-	q.inner.filter.HasTags = &has
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.HasTags = &has })
 }
 
 // StartDate returns a DateFilter for start date filtering.
 func (q *projectQuery) StartDate() DateFilter[ProjectQueryBuilder] {
-	return &dateFilter[ProjectQueryBuilder]{query: q.inner, parent: q, field: dateFieldStartDate}
+	return &dateFilter[ProjectQueryBuilder]{with: q.withFilter, field: dateFieldStartDate}
 }
 
 // StopDate returns a DateFilter for stop date filtering.
 func (q *projectQuery) StopDate() DateFilter[ProjectQueryBuilder] {
-	return &dateFilter[ProjectQueryBuilder]{query: q.inner, parent: q, field: dateFieldStopDate}
+	return &dateFilter[ProjectQueryBuilder]{with: q.withFilter, field: dateFieldStopDate}
 }
 
 // Deadline returns a DateFilter for deadline filtering.
 func (q *projectQuery) Deadline() DateFilter[ProjectQueryBuilder] {
-	return &dateFilter[ProjectQueryBuilder]{query: q.inner, parent: q, field: dateFieldDeadline}
+	return &dateFilter[ProjectQueryBuilder]{with: q.withFilter, field: dateFieldDeadline}
 }
 
 // CreatedAfter filters projects created after the specified time.
 func (q *projectQuery) CreatedAfter(t time.Time) ProjectQueryBuilder {
-	q.inner.filter.CreatedAfter = &t
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.CreatedAfter = &t })
 }
 
 // Search filters projects by a search query.
 func (q *projectQuery) Search(query string) ProjectQueryBuilder {
-	q.inner.filter.SearchQuery = &query
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.SearchQuery = &query })
 }
 
 // Limit restricts the maximum number of results returned.
 func (q *projectQuery) Limit(n int) ProjectQueryBuilder {
-	q.inner.filter.Limit = &n
-	return q
+	return q.withFilter(func(f *database.TaskFilter) { f.Limit = &n })
 }
 
 // All executes the query and returns all matching projects.
+// The result is never nil; an empty result encodes as a JSON array.
 func (q *projectQuery) All(ctx context.Context) ([]Project, error) {
 	rows, err := q.inner.database.inner.QueryTasks(ctx, &q.inner.filter)
 	if err != nil {
 		return nil, err
 	}
 
-	var projects []Project
+	projects := make([]Project, 0, len(rows))
 	for i := range rows {
 		project := convertTaskRowToProject(&rows[i])
 
@@ -364,8 +382,13 @@ func (q *projectQuery) All(ctx context.Context) ([]Project, error) {
 }
 
 // First executes the query and returns the first matching project.
+// It fetches at most one row via a private copy, leaving the receiver unchanged.
 func (q *projectQuery) First(ctx context.Context) (*Project, error) {
-	projects, err := q.All(ctx)
+	one := 1
+	c := q.clone()
+	c.inner.filter.Limit = &one
+
+	projects, err := c.All(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -386,14 +409,14 @@ func (q *projectQuery) Count(ctx context.Context) (int, error) {
 
 // headingQuery provides a fluent interface for building heading queries.
 type headingQuery struct {
-	inner *taskQuery
+	inner taskQuery
 }
 
 // Headings creates a new headingQuery for querying headings.
 func (d *db) Headings() *headingQuery {
 	taskType := int(taskTypeHeading)
 	return &headingQuery{
-		inner: &taskQuery{
+		inner: taskQuery{
 			database: d,
 			filter: database.TaskFilter{
 				Index:    database.IndexDefault,
@@ -403,25 +426,42 @@ func (d *db) Headings() *headingQuery {
 	}
 }
 
+// clone returns a shallow copy of the query for copy-on-write chaining.
+func (q *headingQuery) clone() *headingQuery {
+	c := *q
+	return &c
+}
+
 // WithUUID filters headings by UUID (exact match).
 func (q *headingQuery) WithUUID(uuid string) HeadingQueryBuilder {
-	q.inner.filter.UUID = &uuid
-	return q
+	c := q.clone()
+	c.inner.filter.UUID = &uuid
+	return c
+}
+
+// WithUUIDPrefix filters headings by UUID prefix (LIKE match).
+func (q *headingQuery) WithUUIDPrefix(prefix string) HeadingQueryBuilder {
+	c := q.clone()
+	c.inner.filter.UUIDPrefix = &prefix
+	return c
 }
 
 // InProject filters headings by a specific project UUID.
 func (q *headingQuery) InProject(uuid string) HeadingQueryBuilder {
-	q.inner.filter.ProjectUUID = &uuid
-	return q
+	c := q.clone()
+	c.inner.filter.ProjectUUID = &uuid
+	return c
 }
 
 // Limit restricts the maximum number of results returned.
 func (q *headingQuery) Limit(n int) HeadingQueryBuilder {
-	q.inner.filter.Limit = &n
-	return q
+	c := q.clone()
+	c.inner.filter.Limit = &n
+	return c
 }
 
 // All executes the query and returns all matching headings.
+// The result is never nil; an empty result encodes as a JSON array.
 func (q *headingQuery) All(ctx context.Context) ([]Heading, error) {
 	rows, err := q.inner.database.inner.QueryTasks(ctx, &q.inner.filter)
 	if err != nil {
@@ -437,8 +477,13 @@ func (q *headingQuery) All(ctx context.Context) ([]Heading, error) {
 }
 
 // First executes the query and returns the first matching heading.
+// It fetches at most one row via a private copy, leaving the receiver unchanged.
 func (q *headingQuery) First(ctx context.Context) (*Heading, error) {
-	headings, err := q.All(ctx)
+	one := 1
+	c := q.clone()
+	c.inner.filter.Limit = &one
+
+	headings, err := c.All(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/query_area.go
+++ b/query_area.go
@@ -7,6 +7,8 @@ import (
 )
 
 // areaQuery provides a fluent interface for building area queries.
+// Chainable methods are copy-on-write: each call returns a new builder, so an
+// areaQuery can be forked into independent queries.
 type areaQuery struct {
 	database *db
 	filter   database.AreaFilter
@@ -19,46 +21,58 @@ func (d *db) Areas() *areaQuery {
 	}
 }
 
+// clone returns a shallow copy of the query for copy-on-write chaining.
+func (q *areaQuery) clone() *areaQuery {
+	c := *q
+	return &c
+}
+
 // WithUUID filters areas by UUID.
 func (q *areaQuery) WithUUID(uuid string) AreaQueryBuilder {
-	q.filter.UUID = &uuid
-	return q
+	c := q.clone()
+	c.filter.UUID = &uuid
+	return c
 }
 
 // WithTitle filters areas by title.
 func (q *areaQuery) WithTitle(title string) AreaQueryBuilder {
-	q.filter.Title = &title
-	return q
+	c := q.clone()
+	c.filter.Title = &title
+	return c
 }
 
 // Visible filters areas by visibility status.
 // Pass true to include only visible areas.
 // Pass false to include only hidden areas.
 func (q *areaQuery) Visible(visible bool) AreaQueryBuilder {
-	q.filter.Visible = &visible
-	return q
+	c := q.clone()
+	c.filter.Visible = &visible
+	return c
 }
 
 // InTag filters areas by a specific tag title.
 func (q *areaQuery) InTag(title string) AreaQueryBuilder {
-	q.filter.TagTitle = &title
-	return q
+	c := q.clone()
+	c.filter.TagTitle = &title
+	return c
 }
 
 // HasTag filters areas by whether they have any tags.
 func (q *areaQuery) HasTag(has bool) AreaQueryBuilder {
-	q.filter.HasTag = &has
-	return q
+	c := q.clone()
+	c.filter.HasTag = &has
+	return c
 }
 
 // All executes the query and returns all matching areas.
+// The result is never nil; an empty result encodes as a JSON array.
 func (q *areaQuery) All(ctx context.Context) ([]Area, error) {
 	rows, err := q.database.inner.QueryAreas(ctx, q.filter)
 	if err != nil {
 		return nil, err
 	}
 
-	var areas []Area
+	areas := make([]Area, 0, len(rows))
 	for _, row := range rows {
 		area := convertAreaRow(row)
 

--- a/query_filter.go
+++ b/query_filter.go
@@ -19,41 +19,42 @@ const (
 	dateFieldDeadline
 )
 
+// withTaskFilter clones the parent builder, applies a mutation to the clone's
+// filter, and returns the clone as T. Sub-filters hold this callback instead
+// of the parent's mutable state, so every terminal call forks a fresh copy of
+// the parent snapshot captured at factory time.
+type withTaskFilter[T any] func(mutate func(*database.TaskFilter)) T
+
 // =============================================================================
 // statusFilter - Generic type-safe status filtering
 // =============================================================================
 
 // statusFilter provides type-safe status filtering for any query builder.
 type statusFilter[T any] struct {
-	query  *taskQuery
-	parent T
+	with withTaskFilter[T]
 }
 
 // Incomplete filters for items with incomplete status.
 func (f *statusFilter[T]) Incomplete() T {
 	v := int(StatusIncomplete)
-	f.query.filter.Status = &v
-	return f.parent
+	return f.with(func(tf *database.TaskFilter) { tf.Status = &v })
 }
 
 // Completed filters for items with completed status.
 func (f *statusFilter[T]) Completed() T {
 	v := int(StatusCompleted)
-	f.query.filter.Status = &v
-	return f.parent
+	return f.with(func(tf *database.TaskFilter) { tf.Status = &v })
 }
 
 // Canceled filters for items with canceled status.
 func (f *statusFilter[T]) Canceled() T {
 	v := int(StatusCanceled)
-	f.query.filter.Status = &v
-	return f.parent
+	return f.with(func(tf *database.TaskFilter) { tf.Status = &v })
 }
 
 // Any clears the status filter to include items of any status.
 func (f *statusFilter[T]) Any() T {
-	f.query.filter.Status = nil
-	return f.parent
+	return f.with(func(tf *database.TaskFilter) { tf.Status = nil })
 }
 
 // =============================================================================
@@ -62,29 +63,25 @@ func (f *statusFilter[T]) Any() T {
 
 // startFilter provides type-safe start bucket filtering for any query builder.
 type startFilter[T any] struct {
-	query  *taskQuery
-	parent T
+	with withTaskFilter[T]
 }
 
 // Inbox filters for items in the Inbox.
 func (f *startFilter[T]) Inbox() T {
 	v := int(StartInbox)
-	f.query.filter.Start = &v
-	return f.parent
+	return f.with(func(tf *database.TaskFilter) { tf.Start = &v })
 }
 
 // Anytime filters for items scheduled as Anytime.
 func (f *startFilter[T]) Anytime() T {
 	v := int(StartAnytime)
-	f.query.filter.Start = &v
-	return f.parent
+	return f.with(func(tf *database.TaskFilter) { tf.Start = &v })
 }
 
 // Someday filters for items scheduled as Someday.
 func (f *startFilter[T]) Someday() T {
 	v := int(StartSomeday)
-	f.query.filter.Start = &v
-	return f.parent
+	return f.with(func(tf *database.TaskFilter) { tf.Start = &v })
 }
 
 // =============================================================================
@@ -93,67 +90,61 @@ func (f *startFilter[T]) Someday() T {
 
 // dateFilter provides type-safe date filtering for any query builder.
 type dateFilter[T any] struct {
-	query  *taskQuery
-	parent T
-	field  dateField
+	with  withTaskFilter[T]
+	field dateField
 }
 
 // Exists filters by whether the date exists (is not null).
 func (f *dateFilter[T]) Exists(has bool) T {
-	f.setFilter(&database.DateFilterValue{HasDate: &has})
-	return f.parent
+	return f.set(&database.DateFilterValue{HasDate: &has})
 }
 
 // Future filters for dates in the future (after today).
 func (f *dateFilter[T]) Future() T {
-	f.setFilter(&database.DateFilterValue{Relative: database.DateFuture})
-	return f.parent
+	return f.set(&database.DateFilterValue{Relative: database.DateFuture})
 }
 
 // Past filters for dates in the past (today or earlier).
 func (f *dateFilter[T]) Past() T {
-	f.setFilter(&database.DateFilterValue{Relative: database.DatePast})
-	return f.parent
+	return f.set(&database.DateFilterValue{Relative: database.DatePast})
 }
 
 // On filters for a specific date (equals).
 func (f *dateFilter[T]) On(date time.Time) T {
-	f.setFilter(&database.DateFilterValue{Operator: "=", Date: &date})
-	return f.parent
+	return f.set(&database.DateFilterValue{Operator: "=", Date: &date})
 }
 
 // Before filters for dates before the given date (exclusive).
 func (f *dateFilter[T]) Before(date time.Time) T {
-	f.setFilter(&database.DateFilterValue{Operator: "<", Date: &date})
-	return f.parent
+	return f.set(&database.DateFilterValue{Operator: "<", Date: &date})
 }
 
 // OnOrBefore filters for dates on or before the given date (inclusive).
 func (f *dateFilter[T]) OnOrBefore(date time.Time) T {
-	f.setFilter(&database.DateFilterValue{Operator: "<=", Date: &date})
-	return f.parent
+	return f.set(&database.DateFilterValue{Operator: "<=", Date: &date})
 }
 
 // After filters for dates after the given date (exclusive).
 func (f *dateFilter[T]) After(date time.Time) T {
-	f.setFilter(&database.DateFilterValue{Operator: ">", Date: &date})
-	return f.parent
+	return f.set(&database.DateFilterValue{Operator: ">", Date: &date})
 }
 
 // OnOrAfter filters for dates on or after the given date (inclusive).
 func (f *dateFilter[T]) OnOrAfter(date time.Time) T {
-	f.setFilter(&database.DateFilterValue{Operator: ">=", Date: &date})
-	return f.parent
+	return f.set(&database.DateFilterValue{Operator: ">=", Date: &date})
 }
 
-// setFilter sets the filter value on the appropriate field in the parent query.
-func (f *dateFilter[T]) setFilter(v *database.DateFilterValue) {
-	switch f.field {
-	case dateFieldStartDate:
-		f.query.filter.StartDateFilter = v
-	case dateFieldStopDate:
-		f.query.filter.StopDateFilter = v
-	case dateFieldDeadline:
-		f.query.filter.DeadlineFilter = v
-	}
+// set forks the parent with the filter value applied to the appropriate field.
+func (f *dateFilter[T]) set(v *database.DateFilterValue) T {
+	field := f.field
+	return f.with(func(tf *database.TaskFilter) {
+		switch field {
+		case dateFieldStartDate:
+			tf.StartDateFilter = v
+		case dateFieldStopDate:
+			tf.StopDateFilter = v
+		case dateFieldDeadline:
+			tf.DeadlineFilter = v
+		}
+	})
 }

--- a/query_immutability_test.go
+++ b/query_immutability_test.go
@@ -1,0 +1,216 @@
+package things3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moond4rk/things3/thingstest"
+)
+
+// newThingstestClient creates a Client backed by a writable copy of the
+// thingstest fixture database.
+func newThingstestClient(t *testing.T) *Client {
+	t.Helper()
+	client, err := NewClient(WithDatabasePath(thingstest.DatabasePath(t)))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+// =============================================================================
+// Copy-on-Write Fork Isolation Tests
+// =============================================================================
+
+// TestTodoBuilderForkIsolation verifies that forking a base builder produces
+// independent queries: filters applied on one fork must not leak into the
+// other fork or back into the base.
+func TestTodoBuilderForkIsolation(t *testing.T) {
+	client := newThingstestClient(t)
+	ctx := t.Context()
+
+	base := client.Todos().Status().Incomplete()
+
+	fork1, err := base.StartDate().Past().All(ctx)
+	require.NoError(t, err)
+	fork2, err := base.Deadline().Exists(true).All(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, fork1, 3, "fork1 must only carry incomplete + StartDate().Past()")
+	assert.Len(t, fork2, 4, "fork2 must only carry incomplete + Deadline().Exists(true)")
+
+	baseCount, err := base.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, thingstest.TodosIncomplete, baseCount,
+		"base builder must stay unaffected by forks")
+}
+
+// TestTodoBuilderChainAccumulates verifies that chaining within a single
+// chain still accumulates all filters.
+func TestTodoBuilderChainAccumulates(t *testing.T) {
+	client := newThingstestClient(t)
+	ctx := t.Context()
+
+	todos, err := client.Todos().
+		Status().Incomplete().
+		StartDate().Past().
+		Deadline().Exists(true).
+		All(ctx)
+	require.NoError(t, err)
+	assert.Len(t, todos, 1, "single chain must accumulate all three filters")
+}
+
+// TestSubFilterFactoryCopies verifies that terminal calls on sub-filter
+// factories (Status(), Start(), date filters) copy the parent snapshot
+// instead of mutating it.
+func TestSubFilterFactoryCopies(t *testing.T) {
+	client := newThingstestClient(t)
+	ctx := t.Context()
+
+	base := client.Todos()
+
+	incompleteCount, err := base.Status().Incomplete().Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, thingstest.TodosIncomplete, incompleteCount)
+
+	baseCount, err := base.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 37, baseCount, "Status().Incomplete() must not mutate the base builder")
+
+	statusFactory := base.Status()
+	completedCount, err := statusFactory.Completed().Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, thingstest.TodosComplete, completedCount)
+
+	incompleteAgain, err := statusFactory.Incomplete().Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, thingstest.TodosIncomplete, incompleteAgain,
+		"reusing a sub-filter factory must fork, not overwrite")
+}
+
+// TestBuilderForkIsolationAllTypes verifies copy-on-write across project,
+// heading, area, and tag builders by comparing forked results against fresh
+// single-chain baselines.
+func TestBuilderForkIsolationAllTypes(t *testing.T) {
+	client := newThingstestClient(t)
+	ctx := t.Context()
+
+	t.Run("project builder", func(t *testing.T) {
+		defaultCount, err := client.Projects().Count(ctx)
+		require.NoError(t, err)
+		trashedCount, err := client.Projects().Trashed(true).Count(ctx)
+		require.NoError(t, err)
+		require.NotEqual(t, defaultCount, trashedCount, "fixture must distinguish the two queries")
+
+		base := client.Projects()
+		forkCount, err := base.Trashed(true).Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, trashedCount, forkCount)
+
+		baseCount, err := base.Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, defaultCount, baseCount, "fork must not mutate the base project builder")
+	})
+
+	t.Run("heading builder", func(t *testing.T) {
+		defaultCount, err := client.Headings().Count(ctx)
+		require.NoError(t, err)
+		require.Positive(t, defaultCount)
+
+		base := client.Headings()
+		forkCount, err := base.InProject("nonexistent-project").Count(ctx)
+		require.NoError(t, err)
+		assert.Zero(t, forkCount)
+
+		baseCount, err := base.Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, defaultCount, baseCount, "fork must not mutate the base heading builder")
+	})
+
+	t.Run("area builder", func(t *testing.T) {
+		base := client.Areas()
+		forkAreas, err := base.WithTitle("Area 1").All(ctx)
+		require.NoError(t, err)
+		assert.Len(t, forkAreas, 1)
+
+		baseAreas, err := base.All(ctx)
+		require.NoError(t, err)
+		assert.Len(t, baseAreas, thingstest.Areas, "fork must not mutate the base area builder")
+	})
+
+	t.Run("tag builder", func(t *testing.T) {
+		base := client.Tags()
+		forkTags, err := base.WithTitle("Home").All(ctx)
+		require.NoError(t, err)
+		assert.Len(t, forkTags, 1)
+
+		baseTags, err := base.All(ctx)
+		require.NoError(t, err)
+		assert.Len(t, baseTags, thingstest.Tags, "fork must not mutate the base tag builder")
+	})
+}
+
+// =============================================================================
+// First() Side Effect Tests
+// =============================================================================
+
+// TestTodoFirstDoesNotMutateBuilder verifies that First() applies its
+// checklist auto-include and limit only to its own copy: All() on the
+// original builder afterwards must not return checklists.
+func TestTodoFirstDoesNotMutateBuilder(t *testing.T) {
+	client := newThingstestClient(t)
+	ctx := t.Context()
+
+	q := client.Todos().WithUUID(thingstest.UUIDTodoChecklist)
+
+	first, err := q.First(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, first.Checklist, "First() keeps auto-including the checklist")
+
+	todos, err := q.All(ctx)
+	require.NoError(t, err)
+	require.Len(t, todos, 1)
+	assert.Empty(t, todos[0].Checklist,
+		"All() on the original builder must not inherit First()'s checklist opt-in")
+}
+
+// TestFirstDoesNotLeakLimit verifies that the Limit(1) pushed by First()
+// stays on First()'s private copy.
+func TestFirstDoesNotLeakLimit(t *testing.T) {
+	client := newThingstestClient(t)
+	ctx := t.Context()
+
+	q := client.Todos().Status().Incomplete()
+
+	_, err := q.First(ctx)
+	require.NoError(t, err)
+
+	todos, err := q.All(ctx)
+	require.NoError(t, err)
+	assert.Len(t, todos, thingstest.TodosIncomplete,
+		"All() after First() must return the full result set")
+}
+
+// TestFirstStateIsolationWhitebox asserts directly on internal state that
+// First() leaves the receiver untouched.
+func TestFirstStateIsolationWhitebox(t *testing.T) {
+	db := newTestDB(t)
+	ctx := t.Context()
+
+	tq := db.Todos()
+	_, err := tq.First(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, tq.inner.filter.Limit, "First() must not set Limit on the receiver")
+	assert.False(t, tq.inner.includeChecklist, "First() must not set includeChecklist on the receiver")
+
+	pq := db.Projects()
+	_, err = pq.First(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, pq.inner.filter.Limit, "project First() must not set Limit on the receiver")
+
+	hq := db.Headings()
+	_, err = hq.First(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, hq.inner.filter.Limit, "heading First() must not set Limit on the receiver")
+}

--- a/query_tag.go
+++ b/query_tag.go
@@ -7,6 +7,8 @@ import (
 )
 
 // tagQuery provides a fluent interface for building tag queries.
+// Chainable methods are copy-on-write: each call returns a new builder, so a
+// tagQuery can be forked into independent queries.
 type tagQuery struct {
 	database *db
 	filter   database.TagFilter
@@ -19,26 +21,36 @@ func (d *db) Tags() *tagQuery {
 	}
 }
 
+// clone returns a shallow copy of the query for copy-on-write chaining.
+func (q *tagQuery) clone() *tagQuery {
+	c := *q
+	return &c
+}
+
 // WithUUID filters tags by UUID.
 func (q *tagQuery) WithUUID(uuid string) TagQueryBuilder {
-	q.filter.UUID = &uuid
-	return q
+	c := q.clone()
+	c.filter.UUID = &uuid
+	return c
 }
 
 // WithTitle filters tags by title.
 func (q *tagQuery) WithTitle(title string) TagQueryBuilder {
-	q.filter.Title = &title
-	return q
+	c := q.clone()
+	c.filter.Title = &title
+	return c
 }
 
 // WithParent filters tags by parent tag UUID.
 // Use this to find child tags of a specific parent tag.
 func (q *tagQuery) WithParent(parentUUID string) TagQueryBuilder {
-	q.filter.ParentUUID = &parentUUID
-	return q
+	c := q.clone()
+	c.filter.ParentUUID = &parentUUID
+	return c
 }
 
 // All executes the query and returns all matching tags.
+// The result is never nil; an empty result encodes as a JSON array.
 func (q *tagQuery) All(ctx context.Context) ([]Tag, error) {
 	rows, err := q.database.inner.QueryTags(ctx, q.filter)
 	if err != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,7 @@
 package things3
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -937,4 +938,99 @@ func TestTagWithParent(t *testing.T) {
 	tags, err := db.Tags().WithParent("nonexistent").All(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, tags)
+}
+
+// =============================================================================
+// UUID Prefix Filter Tests
+// =============================================================================
+
+func TestWithUUIDPrefix(t *testing.T) {
+	db := newTestDB(t)
+	ctx := t.Context()
+
+	const (
+		testUUIDHeadingCompleted = "CmpltdHdngTestFixture1"
+		prefixNoMatch            = "zzzzzz"
+	)
+
+	todoUUIDs := func(prefix string) ([]string, error) {
+		todos, err := db.Todos().WithUUIDPrefix(prefix).All(ctx)
+		return extractTodoUUIDs(todos), err
+	}
+	projectUUIDs := func(prefix string) ([]string, error) {
+		projects, err := db.Projects().WithUUIDPrefix(prefix).All(ctx)
+		uuids := make([]string, len(projects))
+		for i := range projects {
+			uuids[i] = projects[i].UUID
+		}
+		return uuids, err
+	}
+	headingUUIDs := func(prefix string) ([]string, error) {
+		headings, err := db.Headings().WithUUIDPrefix(prefix).All(ctx)
+		uuids := make([]string, len(headings))
+		for i := range headings {
+			uuids[i] = headings[i].UUID
+		}
+		return uuids, err
+	}
+
+	tests := []struct {
+		name   string
+		query  func(prefix string) ([]string, error)
+		prefix string
+		want   []string
+	}{
+		{"todo short prefix", todoUUIDs, testUUIDTodoInProject[:6], []string{testUUIDTodoInProject}},
+		{"todo full uuid", todoUUIDs, testUUIDTodoInProject, []string{testUUIDTodoInProject}},
+		{"todo no match", todoUUIDs, prefixNoMatch, []string{}},
+		{"project short prefix", projectUUIDs, testUUIDProjectInArea1[:6], []string{testUUIDProjectInArea1}},
+		{"project full uuid", projectUUIDs, testUUIDProjectInArea1, []string{testUUIDProjectInArea1}},
+		{"project trashed excluded by default", projectUUIDs, "Tc7DAB", []string{}},
+		{"project no match", projectUUIDs, prefixNoMatch, []string{}},
+		{"heading short prefix", headingUUIDs, testUUIDHeadingCompleted[:6], []string{testUUIDHeadingCompleted}},
+		{"heading full uuid", headingUUIDs, testUUIDHeadingCompleted, []string{testUUIDHeadingCompleted}},
+		{"heading no match", headingUUIDs, prefixNoMatch, []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query(tt.prefix)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+// =============================================================================
+// Empty Result Encoding Tests
+// =============================================================================
+
+// TestAllEmptyResultsMarshalAsJSONArray verifies that every All() returns a
+// non-nil empty slice when nothing matches, so JSON encodes [] instead of null.
+func TestAllEmptyResultsMarshalAsJSONArray(t *testing.T) {
+	db := newTestDB(t)
+	ctx := t.Context()
+	const nonexistent = "nonexistent-uuid"
+
+	tests := []struct {
+		name string
+		all  func() (any, error)
+	}{
+		{"todo slice", func() (any, error) { return db.Todos().WithUUID(nonexistent).All(ctx) }},
+		{"project slice", func() (any, error) { return db.Projects().WithUUID(nonexistent).All(ctx) }},
+		{"heading slice", func() (any, error) { return db.Headings().WithUUID(nonexistent).All(ctx) }},
+		{"area slice", func() (any, error) { return db.Areas().WithUUID(nonexistent).All(ctx) }},
+		{"tag slice", func() (any, error) { return db.Tags().WithUUID(nonexistent).All(ctx) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.all()
+			require.NoError(t, err)
+
+			data, err := json.Marshal(got)
+			require.NoError(t, err)
+			assert.Equal(t, "[]", string(data), "empty result must encode as JSON array, not null")
+		})
+	}
 }

--- a/rfcs/011_rfc_cli_redesign.md
+++ b/rfcs/011_rfc_cli_redesign.md
@@ -1,0 +1,128 @@
+# RFC 011: CLI Redesign - Task-Oriented Command Surface
+
+Status: Draft Author: @moond4rk Date: 2026-07-02 Supersedes: RFC 010
+
+## Summary
+
+Redesign the things3 CLI from an API-mirroring, read-only tool into a task-oriented command surface that fuses database queries and URL scheme execution behind user intentions. Users never choose matching modes, never handle full UUIDs, and gain full write access (add, complete, cancel, edit, move, open) with database-backed verification that pure URL-scheme tools cannot provide.
+
+## Motivation
+
+The current CLI (RFC 010) has three structural problems:
+
+1. **Read-only.** The library's entire write surface (TodoAdder, TodoUpdater, ShowNavigator, batch operations) is unreachable from the command line.
+2. **Implementation details leak.** Users must choose a matching mode (`--title` vs `--search` vs positional UUID), know that `project` requires a full UUID while `todo` accepts a prefix, and navigate a `list` subcommand that mixes todo views (inbox, today) with domain collections (projects, areas, tags).
+3. **Database and scheme are not fused.** The short UUIDs the CLI displays cannot be fed back into `project`. Write operations, once added naively, would be fire-and-forget with no confirmation and no way to reference the created item.
+
+## Design
+
+### Principles
+
+1. **Task-oriented, not API-oriented.** Commands express what the user wants (see today, finish a task), not which library method runs.
+2. **Human identifiers.** Every command accepting a task reference resolves it through one shared algorithm over titles and UUID prefixes. Users are never required to look up a UUID.
+3. **Read-write fusion.** Write commands are three-phase: resolve (database) -> execute (URL scheme) -> verify (database). The database makes writes addressable and confirmable; the scheme makes the database actionable.
+4. **Script-friendly.** Single `--output` flag, semantic exit codes, empty collections encode as `[]`, created items echo their real UUID.
+5. **Progressive disclosure.** Frequent operations are shortest. Internal concepts (start buckets, deadline suppression, todayIndex, trashed-parent cascades, auth tokens) never appear in help or output.
+
+### Command Surface
+
+```
+Views (top level, replacing `list <view>`):
+  things3 today | inbox | upcoming | anytime | someday
+  things3 logbook [--days N] | deadlines | trash
+
+Collections:
+  things3 projects [--area <q>] [--all]
+  things3 areas
+  things3 tags
+
+Lookup:
+  things3 show <query>          resolve across todos and projects;
+                                1 match -> detail, N -> list, 0 -> exit 1
+  things3 search <query>        full-text search across todos and projects
+
+Actions:
+  things3 add "title" [--notes s] [--when W] [--deadline D] [--reminder HH:MM]
+              [--project <q> | --area <q> | --heading <q>]
+              [--tags a,b] [--checklist "x" --checklist "y"]
+  things3 add project "title" [--area <q>] [--notes s] [--when W] [--deadline D] [--todos "a" --todos "b"]
+  things3 done <query>
+  things3 cancel <query>
+  things3 edit <query> [--title s] [--notes s] [--append-notes s] [--when W]
+              [--deadline D] [--clear-deadline] [--tags a,b] [--add-tags c]
+  things3 move <query> --to <project-q | area-q | inbox | today | anytime | someday>
+  things3 open [<query> | <view>]   reveal in the Things app
+
+Misc:
+  things3 version
+
+Global flags:
+  -o, --output text|json|yaml   (replaces --json / --yaml)
+  -n, --limit N
+      --db <path>               (overrides THINGSDB and auto-discovery)
+```
+
+Command groups (cobra groups) keep help readable: Views, Collections, Lookup, Actions.
+
+Removed relative to RFC 010: `list` (views move to top level), `todo` and `project` detail commands (unified into `show`), all matching-mode flags (`--title`, `--search`, `--uuid`). Per project policy there is no backward compatibility or deprecation period.
+
+### Identifier Resolution
+
+One resolver shared by `show`, `done`, `cancel`, `edit`, `move`, `open`, and the `--project`/`--area`/`--heading` flags:
+
+1. Exact UUID match (todos and projects).
+2. UUID prefix match.
+3. Exact title match, case-insensitive.
+4. Title substring match.
+
+First tier with hits wins; hits merge across todos and projects with incomplete items ranked before closed ones. Resolution outcome:
+
+- Exactly one match: proceed.
+- Multiple matches: read commands (`show`) print the list normally and exit 0; write commands print candidates (short UUID, type, title) to stderr and exit 2 without executing. Writes require an unambiguous target.
+- Zero matches: message to stderr, exit 1.
+
+The 8-character short UUIDs the CLI prints are always valid inputs, closing the current round-trip break.
+
+### Write-Path Fusion
+
+`done <q>`: resolve to full UUID and type -> `UpdateTodo(uuid).Completed(true).Execute()` -> poll the database (short interval, roughly 2s budget) until the status flips -> print the confirmed item. On verification timeout, report "sent to Things, not yet confirmed" and exit 0; the send itself succeeded.
+
+`add "title"`: record t0 -> execute the add -> poll `Todos().WithTitle(title).CreatedAfter(t0)` -> print the created item with its real UUID (JSON output includes the full model). This gives scripts a handle to the new item, which fire-and-forget URL scheme tools cannot provide. On timeout, same unconfirmed semantics as above.
+
+`--when` values (`today`, `tomorrow`, `evening`, `someday`, `anytime`, `yyyy-mm-dd`) parse through a strict variant of ApplyWhen that rejects unknown input with an error instead of silently ignoring it.
+
+Deliberate scope cuts: no `delete` (the URL scheme cannot trash items; `cancel` plus the app covers it), no checklist mutation beyond add/replace (scheme limitation), no repeating-task management (not in the scheme).
+
+### Output and Exit Codes
+
+- `--output text` (default): current compact line and detail formats, plus Reminder in the detail view.
+- `--output json|yaml`: full models; empty result sets encode as `[]`, never `null`.
+- Exit codes: 0 success (including empty view listings), 1 error or zero-match lookup, 2 ambiguous write target.
+- `--json --yaml` style conflicts become impossible by construction (one enum flag).
+
+## Implementation Notes
+
+### Library Prerequisites
+
+Ordered by how hard they block the CLI:
+
+1. `ProjectQueryBuilder.WithUUIDPrefix` - resolver cannot work for projects without it.
+2. Timezone model fix (scan parses localtime strings as UTC; `CreatedAfter` formats the caller's wall clock instead of normalizing to local) - `add` verification and `logbook --days` are unreliable until fixed.
+3. LIKE metacharacter escaping (`%`, `_`) - resolver title matching must be literal.
+4. Strict when-parser (`ParseWhen` returning an error) alongside the lenient `ApplyWhen`.
+5. `client.Today(ctx)` encapsulating the three-query Today composition, removing `DeadlineSuppressed` from the public surface.
+6. Empty query results return empty slices, not nil (JSON `[]`).
+7. Sort support for recency-ordered views (logbook by stop date descending, deadlines by deadline, upcoming by start date); client-side sorting in the CLI is an acceptable interim.
+8. Optional, later: promote the resolver into the library (`client.Resolve`) once CLI usage stabilizes its semantics.
+
+### Phasing
+
+1. Library fixes above (items 1-6 minimum).
+2. CLI skeleton migration: top-level views, `--output`, `--db`, exit codes, shared client bootstrap helper, command groups.
+3. Resolver plus `show`/`search` unification.
+4. Write commands: `add`, `done`, `cancel`, `edit`, `move`, `open`, with verification loops.
+5. Tests against the fixture database via `--db` (the CLI currently has zero tests; the bootstrap helper plus `--db` makes command-level testing possible), README rewrite, cobra completion.
+
+### Testing
+
+Every command gets table-driven tests running against `testdata/main.sqlite` through `--db`, asserting stdout, stderr, and exit codes. Write commands are tested up to URL construction (scheme execution mocked or skipped off-macOS); resolution and verification logic are testable purely against the fixture.

--- a/thingstest/thingstest.go
+++ b/thingstest/thingstest.go
@@ -27,6 +27,12 @@ import (
 	"testing"
 )
 
+// SQLite WAL-mode sidecar file suffixes.
+const (
+	walSuffix = "-wal"
+	shmSuffix = "-shm"
+)
+
 var (
 	sourcePath     string
 	initSourcePath = sync.OnceFunc(func() {
@@ -37,28 +43,58 @@ var (
 )
 
 // DatabasePath copies the things3 test fixture database to a temporary
-// directory and returns the path to the copy. The temporary file is
+// directory and returns the path to the copy. The temporary files are
 // automatically cleaned up when the test finishes.
 //
 // Copying is necessary because the module cache is read-only and SQLite
 // requires write access to the directory for lock files, even in read-only
 // mode. Each test invocation gets its own copy, so parallel tests do not
 // conflict.
+//
+// The fixture is in WAL mode, so the -wal and -shm sidecar files are copied
+// alongside the database when they exist; otherwise uncheckpointed data would
+// be silently lost.
 func DatabasePath(t *testing.T) string {
 	t.Helper()
 	initSourcePath()
 
-	data, err := os.ReadFile(sourcePath)
-	if err != nil {
-		t.Fatalf("thingstest: read fixture database: %v", err)
-	}
+	return copyDatabaseWithSidecars(t, sourcePath, t.TempDir())
+}
 
-	dst := filepath.Join(t.TempDir(), "main.sqlite")
-	if err := os.WriteFile(dst, data, 0o600); err != nil { //nolint:gosec // dst is from t.TempDir(), not user input
-		t.Fatalf("thingstest: write fixture database: %v", err)
+// copyDatabaseWithSidecars copies the database at src plus any -wal/-shm
+// sidecar files into dstDir and returns the path of the copied database.
+func copyDatabaseWithSidecars(t *testing.T, src, dstDir string) string {
+	t.Helper()
+
+	dst := filepath.Join(dstDir, filepath.Base(src))
+	copyFixtureFile(t, src, dst)
+
+	for _, suffix := range []string{walSuffix, shmSuffix} {
+		sidecar := src + suffix
+		if _, err := os.Stat(sidecar); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("thingstest: stat fixture sidecar: %v", err)
+		}
+		copyFixtureFile(t, sidecar, dst+suffix)
 	}
 
 	return dst
+}
+
+// copyFixtureFile copies a fixture file from src to dst, failing the test on
+// any error.
+func copyFixtureFile(t *testing.T, src, dst string) {
+	t.Helper()
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("thingstest: read fixture file: %v", err)
+	}
+	if err := os.WriteFile(dst, data, 0o600); err != nil { //nolint:gosec // dst is from t.TempDir(), not user input
+		t.Fatalf("thingstest: write fixture file: %v", err)
+	}
 }
 
 // SourceDatabasePath returns the absolute path to the original fixture

--- a/thingstest/thingstest_test.go
+++ b/thingstest/thingstest_test.go
@@ -2,6 +2,7 @@ package thingstest
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +41,44 @@ func TestSourceDatabasePath(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	assert.Positive(t, info.Size())
+}
+
+// TestCopyDatabaseWithSidecars verifies that the -wal and -shm sidecar files
+// are copied along with the main database. The fixture is in WAL mode, so
+// dropping the sidecars would silently lose any uncheckpointed data. The test
+// uses its own source files because the shared fixture's sidecars are live
+// SQLite artifacts whose size changes while other tests hold the database open.
+func TestCopyDatabaseWithSidecars(t *testing.T) {
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "main.sqlite")
+	require.NoError(t, os.WriteFile(src, []byte("database bytes"), 0o600))
+	require.NoError(t, os.WriteFile(src+walSuffix, []byte("wal bytes"), 0o600))
+	require.NoError(t, os.WriteFile(src+shmSuffix, []byte("shm bytes"), 0o600))
+
+	dst := copyDatabaseWithSidecars(t, src, t.TempDir())
+
+	for _, suffix := range []string{"", walSuffix, shmSuffix} {
+		want, err := os.ReadFile(src + suffix)
+		require.NoError(t, err)
+		got, err := os.ReadFile(dst + suffix)
+		require.NoError(t, err, "sidecar %q must be copied next to the database", suffix)
+		assert.Equal(t, want, got, "sidecar %q content must match the source", suffix)
+	}
+}
+
+// TestCopyDatabaseWithSidecarsWithoutSidecars verifies that missing sidecar
+// files are tolerated rather than treated as an error.
+func TestCopyDatabaseWithSidecarsWithoutSidecars(t *testing.T) {
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "main.sqlite")
+	require.NoError(t, os.WriteFile(src, []byte("database bytes"), 0o600))
+
+	dst := copyDatabaseWithSidecars(t, src, t.TempDir())
+
+	_, err := os.Stat(dst)
+	require.NoError(t, err)
+	for _, suffix := range []string{walSuffix, shmSuffix} {
+		_, err := os.Stat(dst + suffix)
+		assert.True(t, os.IsNotExist(err), "sidecar %q must not be fabricated", suffix)
+	}
 }

--- a/time_helpers.go
+++ b/time_helpers.go
@@ -1,6 +1,9 @@
 package things3
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Today returns today's date at midnight (00:00:00) in local timezone.
 // This is useful for scheduling todos with When().
@@ -63,6 +66,15 @@ func YearsAgo(n int) time.Time {
 	return time.Now().AddDate(-n, 0, 0)
 }
 
+// When keyword strings accepted by ParseWhen and ApplyWhen.
+const (
+	whenKeywordToday    = "today"
+	whenKeywordTomorrow = "tomorrow"
+	whenKeywordEvening  = "evening"
+	whenKeywordAnytime  = "anytime"
+	whenKeywordSomeday  = "someday"
+)
+
 // WhenScheduler is implemented by builders that support scheduling.
 // All builder types (TodoAdder, ProjectAdder, TodoUpdater,
 // ProjectUpdater, BatchTodoConfigurator, BatchProjectConfigurator) satisfy this interface.
@@ -73,7 +85,7 @@ type WhenScheduler[T any] interface {
 	WhenSomeday() T
 }
 
-// ApplyWhen parses a when string and applies scheduling to a builder.
+// ParseWhen parses a when string and applies scheduling to a builder.
 // Supports:
 //   - "today": schedules for today
 //   - "tomorrow": schedules for tomorrow
@@ -82,7 +94,39 @@ type WhenScheduler[T any] interface {
 //   - "someday": schedules for someday (indefinite future)
 //   - "yyyy-mm-dd": schedules for specific date
 //
-// Returns the builder unchanged if the format is not recognized.
+// Unrecognized input returns the builder unchanged along with a descriptive
+// error. Use ApplyWhen to silently ignore invalid input instead.
+//
+// Example:
+//
+//	todo := client.AddTodo().Title("Buy milk")
+//	todo, err := things3.ParseWhen(todo, "2024-12-25")
+func ParseWhen[T WhenScheduler[T]](b T, when string) (T, error) {
+	switch when {
+	case whenKeywordToday:
+		return b.When(Today()), nil
+	case whenKeywordTomorrow:
+		return b.When(Tomorrow()), nil
+	case whenKeywordEvening:
+		return b.WhenEvening(), nil
+	case whenKeywordAnytime:
+		return b.WhenAnytime(), nil
+	case whenKeywordSomeday:
+		return b.WhenSomeday(), nil
+	default:
+		if t, err := time.Parse(time.DateOnly, when); err == nil {
+			return b.When(t), nil
+		}
+		return b, fmt.Errorf(
+			"things3: unrecognized when value %q (expected today, tomorrow, evening, anytime, someday, or yyyy-mm-dd)",
+			when,
+		)
+	}
+}
+
+// ApplyWhen is the error-ignoring variant of ParseWhen: it applies the parsed
+// scheduling to the builder and silently returns the builder unchanged when
+// the input is not recognized. Use ParseWhen to detect invalid input.
 //
 // Example:
 //
@@ -90,21 +134,6 @@ type WhenScheduler[T any] interface {
 //	todo = things3.ApplyWhen(todo, "today")
 //	todo = things3.ApplyWhen(todo, "2024-12-25")
 func ApplyWhen[T WhenScheduler[T]](b T, when string) T {
-	switch when {
-	case "today":
-		return b.When(Today())
-	case "tomorrow":
-		return b.When(Tomorrow())
-	case "evening":
-		return b.WhenEvening()
-	case "anytime":
-		return b.WhenAnytime()
-	case "someday":
-		return b.WhenSomeday()
-	default:
-		if t, err := time.Parse(time.DateOnly, when); err == nil {
-			return b.When(t)
-		}
-		return b
-	}
+	result, _ := ParseWhen(b, when)
+	return result
 }

--- a/time_helpers_test.go
+++ b/time_helpers_test.go
@@ -88,8 +88,10 @@ func TestParseWhen(t *testing.T) {
 			todo, err := ParseWhen(scheme.AddTodo().Title("Test"), tt.when)
 
 			if tt.wantErr {
-				require.ErrorContains(t, err, tt.when)
 				require.ErrorContains(t, err, "unrecognized when value")
+				if tt.when != "" {
+					require.ErrorContains(t, err, tt.when)
+				}
 			} else {
 				require.NoError(t, err)
 			}

--- a/time_helpers_test.go
+++ b/time_helpers_test.go
@@ -56,6 +56,59 @@ func TestYearsAgo(t *testing.T) {
 	assert.WithinDuration(t, expected, oneYearAgo, time.Second)
 }
 
+// testWhenDate is a fixed calendar date used by the when-parsing tests.
+const testWhenDate = "2024-12-25"
+
+func TestParseWhen(t *testing.T) {
+	scheme := newScheme()
+
+	// Get expected dates for today/tomorrow
+	todayStr := Today().Format(time.DateOnly)
+	tomorrowStr := Tomorrow().Format(time.DateOnly)
+
+	tests := []struct {
+		name     string
+		when     string
+		wantWhen string
+		wantErr  bool
+	}{
+		{"today keyword", whenKeywordToday, todayStr, false},
+		{"tomorrow keyword", whenKeywordTomorrow, tomorrowStr, false},
+		{"evening keyword", whenKeywordEvening, whenKeywordEvening, false},
+		{"anytime keyword", whenKeywordAnytime, whenKeywordAnytime, false},
+		{"someday keyword", whenKeywordSomeday, whenKeywordSomeday, false},
+		{"specific date", testWhenDate, testWhenDate, false},
+		{"unrecognized word", "invalid", "", true},
+		{"malformed date", "2024-13-45", "", true},
+		{"empty string", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			todo, err := ParseWhen(scheme.AddTodo().Title("Test"), tt.when)
+
+			if tt.wantErr {
+				require.ErrorContains(t, err, tt.when)
+				require.ErrorContains(t, err, "unrecognized when value")
+			} else {
+				require.NoError(t, err)
+			}
+
+			thingsURL, err := todo.Build()
+			require.NoError(t, err)
+
+			_, params := parseThingsURL(t, thingsURL)
+			whenValue := params.Get("when")
+
+			if tt.wantErr {
+				assert.Empty(t, whenValue, "builder should be returned unchanged for invalid input")
+			} else {
+				assert.Equal(t, tt.wantWhen, whenValue)
+			}
+		})
+	}
+}
+
 func TestApplyWhen(t *testing.T) {
 	scheme := newScheme()
 
@@ -69,13 +122,13 @@ func TestApplyWhen(t *testing.T) {
 		wantWhen  string
 		wantEmpty bool
 	}{
-		{"today", "today", todayStr, false},
-		{"tomorrow", "tomorrow", tomorrowStr, false},
-		{"evening", "evening", "evening", false},
-		{"anytime", "anytime", "anytime", false},
-		{"someday", "someday", "someday", false},
-		{"specific date", "2024-12-25", "2024-12-25", false},
-		{"invalid format unchanged", "invalid", "", true},
+		{"today keyword", whenKeywordToday, todayStr, false},
+		{"tomorrow keyword", whenKeywordTomorrow, tomorrowStr, false},
+		{"evening keyword", whenKeywordEvening, whenKeywordEvening, false},
+		{"anytime keyword", whenKeywordAnytime, whenKeywordAnytime, false},
+		{"someday keyword", whenKeywordSomeday, whenKeywordSomeday, false},
+		{"specific date", testWhenDate, testWhenDate, false},
+		{"invalid format silently ignored", "invalid", "", true},
 	}
 
 	for _, tt := range tests {
@@ -104,7 +157,7 @@ func TestApplyWhenWithDifferentBuilders(t *testing.T) {
 
 	// Test AddTodoBuilder
 	todo := scheme.AddTodo().Title("Todo")
-	todo = ApplyWhen(todo, "today")
+	todo = ApplyWhen(todo, whenKeywordToday)
 	todoURL, err := todo.Build()
 	require.NoError(t, err)
 	_, todoParams := parseThingsURL(t, todoURL)
@@ -112,7 +165,7 @@ func TestApplyWhenWithDifferentBuilders(t *testing.T) {
 
 	// Test AddProjectBuilder
 	project := scheme.AddProject().Title("Project")
-	project = ApplyWhen(project, "tomorrow")
+	project = ApplyWhen(project, whenKeywordTomorrow)
 	projectURL, err := project.Build()
 	require.NoError(t, err)
 	_, projectParams := parseThingsURL(t, projectURL)
@@ -121,17 +174,17 @@ func TestApplyWhenWithDifferentBuilders(t *testing.T) {
 	// Test UpdateTodoBuilder (requires auth token)
 	authScheme := scheme.WithToken("test-token")
 	updateTodo := authScheme.UpdateTodo("test-uuid")
-	updateTodo = ApplyWhen(updateTodo, "evening")
+	updateTodo = ApplyWhen(updateTodo, whenKeywordEvening)
 	updateURL, err := updateTodo.Build()
 	require.NoError(t, err)
 	_, updateParams := parseThingsURL(t, updateURL)
-	assert.Equal(t, "evening", updateParams.Get("when"))
+	assert.Equal(t, whenKeywordEvening, updateParams.Get("when"))
 
 	// Test UpdateProjectBuilder
 	updateProject := authScheme.UpdateProject("test-uuid")
-	updateProject = ApplyWhen(updateProject, "someday")
+	updateProject = ApplyWhen(updateProject, whenKeywordSomeday)
 	updateProjectURL, err := updateProject.Build()
 	require.NoError(t, err)
 	_, updateProjectParams := parseThingsURL(t, updateProjectURL)
-	assert.Equal(t, "someday", updateProjectParams.Get("when"))
+	assert.Equal(t, whenKeywordSomeday, updateProjectParams.Get("when"))
 }

--- a/types.go
+++ b/types.go
@@ -248,9 +248,3 @@ const (
 	JSONItemTypeTodo    = scheme.JSONItemTypeTodo
 	JSONItemTypeProject = scheme.JSONItemTypeProject
 )
-
-// Headings creates heading entries for a project's items.
-// Used within BatchProjectConfigurator.Todos to organize todos under headings.
-func Headings(headings ...string) string {
-	return scheme.Headings(headings...)
-}


### PR DESCRIPTION
## Summary

Fixes 25 defects confirmed by a full library audit, spanning four layers. Every fix was independently cross-verified by adversarial probes (separate verifiers rebuilt pre-fix baselines from git archive HEAD to prove each bug reproduced, then confirmed it no longer does), plus a fresh-eyes regression review over the entire diff with go test -race.

## Breaking Changes

- All timestamps now represent correct instants (previously local wall time mislabeled as UTC, off by the machine UTC offset); StartDate/Deadline are local midnight.
- Query builders are copy-on-write: reusing a base builder no longer leaks filters between forks; First() no longer mutates the builder and pushes LIMIT 1.
- HasProject(false) now means "has no project" (was effectively always true due to OR instead of AND).
- Removed the dead Headings() helper (produced malformed todos, never created headings).
- URL scheme builders now reject invalid input at Build(): tags containing commas, titles/checklist items containing newlines, Reminder combined with someday/anytime, and length limits count characters (runes) instead of bytes.

## internal/database

- Timezone model: SQL selects raw epochs, Go converts via time.Unix/ParseInLocation; CreatedAt.Unix() now equals the raw DB value on any machine timezone
- CreatedAfter and date filters normalize to local time (same instant in any Location yields identical results)
- LIKE metacharacters (%, _, \) escaped with ESCAPE clause; Search("%") no longer matches everything
- Areas().Visible(true) treats NULL as visible (per-call NULL defaults; trashed columns keep default 0)
- Midnight (00:00) reminders no longer dropped; dangling tag references no longer fail whole queries

## internal/scheme

- Build() is pure and idempotent (repeated Build with Reminder no longer corrupts the when parameter)
- AuthBatch only fetches the token when the batch contains updates; empty tokens fail fast with an honest error, single fetch, caller context respected
- Child process stderr captured into returned errors (AppleEvents permission denials now diagnosable)

## Root package

- Copy-on-write builders, side-effect-free First() with LIMIT 1
- ProjectQueryBuilder/HeadingQueryBuilder gain WithUUIDPrefix; empty results encode as [] not null
- New strict ParseWhen (returns error); ApplyWhen is its lenient wrapper
- thingstest copies WAL sidecars

## CLI

- project command accepts the 8-char short UUIDs the CLI itself displays (round trip was broken)
- Zero-match lookups exit nonzero with a stderr message; --json/--yaml mutually exclusive; logbook sorted by completion time descending
- First CLI test coverage (fixture-driven end-to-end)

Also adds RFC 011 (draft): task-oriented CLI redesign proposal whose library prerequisites are fulfilled by this PR.

## Validation

- go test ./... green in both modules; go vet clean; golangci-lint --new-from-rev HEAD: 0 issues
- 6/6 independent verification groups passed; fresh-eyes regression review found no new defects