### PR TITLE
ci: push homebrew formula via moond4rk-ci app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,25 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
     runs-on: macos-latest
     steps:
+      # A moond4rk-ci token scoped to this repo so the tag pushes and the CLI
+      # bump PR are attributed to the app, and so the PR triggers CI: a PR opened
+      # with the default GITHUB_TOKEN does not fire pull_request workflows, which
+      # would leave the auto-merge with no checks to gate on.
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MOOND4RK_CI_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MOOND4RK_CI_RELEASE_APP_PRIVATE_KEY }}
+          owner: moonD4rk
+          repositories: things3
+
       - name: Validate version format
         run: |
           if [[ ! "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
@@ -26,6 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.release-token.outputs.token }}
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -34,10 +49,12 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "moond4rk-ci[bot]"
+          git config user.email "299850723+moond4rk-ci[bot]@users.noreply.github.com"
 
-      # Step 1: Tag the library module on the current commit
+      # Step 1: Tag the library module on the current commit (main HEAD), so the
+      # release-driving tag always lives on main and is never orphaned by the
+      # squash-merge in the final step.
       - name: Tag library module
         run: |
           git tag ${{ inputs.version }}
@@ -58,27 +75,26 @@ jobs:
           echo "Error: Module not indexed after 5 minutes"
           exit 1
 
-      # Step 3: Update CLI module to reference the newly published library version
-      - name: Update CLI module dependency
+      # Step 3: Update the CLI module to require the published library, on a
+      # release branch. The bump reaches main only through the auto-merged PR in
+      # the final step, never a direct push. The CLI tag is created on this
+      # branch commit; Go resolves the module by tag, so it need not sit on main.
+      - name: Update CLI module on a release branch
         run: |
+          BRANCH="chore/cli-${{ inputs.version }}"
+          git switch -c "$BRANCH"
           cd cmd/things3
           GOWORK=off go mod edit -require "github.com/moond4rk/things3@${{ inputs.version }}"
           GOWORK=off go mod tidy
-
-      # Step 4: Commit the CLI module update (if changed), tag for Go module system, push
-      - name: Commit and tag CLI module
-        run: |
+          cd ../..
           git add cmd/things3/go.mod cmd/things3/go.sum
-          if git diff --cached --quiet; then
-            echo "CLI module dependency already up to date, skipping commit"
-          else
+          if ! git diff --cached --quiet; then
             git commit -m "chore: release ${{ inputs.version }}"
-            git push origin HEAD:main
           fi
           git tag "cmd/things3/${{ inputs.version }}"
-          git push origin "cmd/things3/${{ inputs.version }}"
+          git push origin "$BRANCH" "cmd/things3/${{ inputs.version }}"
 
-      # Step 5: Mint a short-lived token scoped to the homebrew-tap repo so
+      # Step 4: Mint a short-lived token scoped to the homebrew-tap repo so
       # GoReleaser pushes the formula update via the moond4rk-ci app instead of
       # a long-lived PAT.
       - name: Mint homebrew-tap token
@@ -90,10 +106,9 @@ jobs:
           owner: moonD4rk
           repositories: homebrew-tap
 
-      # Step 6: Build and publish binaries via GoReleaser
-      # GORELEASER_CURRENT_TAG overrides tag auto-detection so GoReleaser
-      # uses the library tag (v0.5.0) as the release version, even though
-      # HEAD is one commit ahead (the CLI go.mod update commit).
+      # Step 5: Build and publish binaries via GoReleaser.
+      # GORELEASER_CURRENT_TAG pins the release version to the library tag even
+      # though HEAD is the release branch (one commit ahead of that tag).
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -104,3 +119,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}
+
+      # Step 6: Open the CLI bump PR as the app (never a personal account) and let
+      # it auto-merge once CI passes, so main receives the bump through review.
+      - name: Open and auto-merge the CLI bump PR
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        run: |
+          BRANCH="chore/cli-${{ inputs.version }}"
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: release ${{ inputs.version }}" \
+            --body "Updates \`cmd/things3/go.mod\` to require library ${{ inputs.version }}, already published by the release workflow.")
+          gh pr merge "$PR_URL" --auto --squash --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,19 @@ jobs:
           git tag "cmd/things3/${{ inputs.version }}"
           git push origin "cmd/things3/${{ inputs.version }}"
 
-      # Step 5: Build and publish binaries via GoReleaser
+      # Step 5: Mint a short-lived token scoped to the homebrew-tap repo so
+      # GoReleaser pushes the formula update via the moond4rk-ci app instead of
+      # a long-lived PAT.
+      - name: Mint homebrew-tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MOOND4RK_CI_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MOOND4RK_CI_RELEASE_APP_PRIVATE_KEY }}
+          owner: moonD4rk
+          repositories: homebrew-tap
+
+      # Step 6: Build and publish binaries via GoReleaser
       # GORELEASER_CURRENT_TAG overrides tag auto-detection so GoReleaser
       # uses the library tag (v0.5.0) as the release version, even though
       # HEAD is one commit ahead (the CLI go.mod update commit).
@@ -91,4 +103,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,8 +55,8 @@ brews:
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_author:
-      name: "github-actions[bot]"
-      email: "github-actions[bot]@users.noreply.github.com"
+      name: "moond4rk-ci[bot]"
+      email: "299850723+moond4rk-ci[bot]@users.noreply.github.com"
     commit_msg_template: "brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install "things3"


### PR DESCRIPTION
Replace the long-lived Homebrew PAT with a short-lived `moond4rk-ci` app token when pushing the formula to `homebrew-tap`.

- Mint a token scoped to `homebrew-tap` via `create-github-app-token` (client-id) and hand it to GoReleaser as `HOMEBREW_TAP_GITHUB_TOKEN` (was `secrets.MOOND4RK_HOMEBREW_TAP_GITHUB_TOKEN`).
- Attribute the formula-bump commit to `moond4rk-ci[bot]`.

The in-repo tag/commit and GitHub Release still use the default `GITHUB_TOKEN`. Requires the `moond4rk-ci` app installed on `homebrew-tap`.